### PR TITLE
Update requirements for @id and @type in a frame

### DIFF
--- a/common/common.js
+++ b/common/common.js
@@ -190,16 +190,57 @@ require(["core/pubsubhub"], (respecEvents) => {
 
     // Add playground links
     for (const link of document.querySelectorAll("a.playground")) {
-      // First pre element of aside
-      const pre = link.closest("aside").querySelector("pre");
+      let pre;
+      if (link.dataset.resultFor) {
+        // Referenced pre element
+        pre = document.querySelector(link.dataset.resultFor + ' > pre');
+      } else {
+        // First pre element of aside
+        pre = link.closest("aside").querySelector("pre");
+      }
       const content = unComment(document, pre.textContent)
         .replace(/\*\*\*\*/g, '')
         .replace(/####([^#]*)####/g, '');
       link.setAttribute('aria-label', 'playground link');
       link.innerText = "Open in playground";
+
+      // startTab defaults to "expand"
+      const linkQueryParams = {
+        startTab: "tab-expand",
+        "json-ld": content
+      }
+
+      if (link.dataset.compact !== undefined) {
+        linkQueryParams.startTab = "tab-" + "compacted";
+        linkQueryParams.context = '{}';
+      }
+
+      if (link.dataset.flatten !== undefined) {
+        linkQueryParams.startTab = "tab-" + "flattened";
+        linkQueryParams.context = '{}';
+      }
+
+      if (link.dataset.frame !== undefined) {
+        linkQueryParams.startTab = "tab-" + "framed";
+        const frameContent = unComment(document, document.querySelector(link.dataset.frame + ' > pre').innerText)
+          .replace(/\*\*\*\*/g, '')
+          .replace(/####([^#]*)####/g, '');
+        linkQueryParams.frame = frameContent;
+      }
+
+      // Set context
+      if (link.dataset.context) {
+        const contextContent = unComment(document, document.querySelector(link.dataset.context + ' > pre').innerText)
+          .replace(/\*\*\*\*/g, '')
+          .replace(/####([^#]*)####/g, '');
+        linkQueryParams.context = contextContent;
+      }
+
       link.setAttribute('href',
-        'https://json-ld.org/playground-dev/#startTab=tab-expanded&json-ld=' +
-        encodeURI(content));
+        'https://json-ld.org/playground-dev/#' +
+        Object.keys(linkQueryParams).map(k => `${encodeURIComponent(k)}=${encodeURIComponent(linkQueryParams[k])}`)
+              .join('&'));
+
       // Wrap in a button
       const button = document.createElement('button');
       link.parentNode.insertBefore(button, link);

--- a/index.html
+++ b/index.html
@@ -956,8 +956,10 @@ familiar with the basic RDF concepts [[!RDF11-CONCEPTS]].</p>
       allowed in the grammar for values of <a>member</a> keys expanding to <a>absolute IRIs</a>.
       <a>Processors</a> MUST preserve this value when expanding. All other <a>members</a> of
       a <a>default object</a> MUST be ignored.</li>
-    <li>The values of <code>@id</code> and <code>@type</code> may also be an empty <a>dictionary</a>, or an <a>array</a>
-      containing only an empty <a>dictionary</a>.
+    <li>The values of <code>@id</code> and <code>@type</code> may also be an empty <a>dictionary</a>,
+      <span class="changed">an <a>absolute IRI</a></span>,
+      <a>array</a> containing only an empty <a>dictionary</a>,
+      <span class="changed">or an array of <a>absolute IRIs</a></span>.
       <a>Processors</a> MUST preserve this value when expanding.</li>
     <li>Framing either operates on the merged node definitions contained in
       the input document, or on the <a>default graph</a> depending on if the

--- a/tests/frame-manifest.jsonld
+++ b/tests/frame-manifest.jsonld
@@ -446,6 +446,24 @@
       "frame": "frame/0051-frame.jsonld",
       "expect": "frame/0051-out.jsonld"
     }, {
+      "@id": "#t0052",
+      "@type": ["jld:NegativeEvaluationTest", "jld:FrameTest"],
+      "name": "@id must not include a blank node identifier",
+      "purpose": "Node matching does not consider blank nodes.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "frame/0052-in.jsonld",
+      "frame": "frame/0052-frame.jsonld",
+      "expect": "invalid frame"
+    }, {
+      "@id": "#t0053",
+      "@type": ["jld:NegativeEvaluationTest", "jld:FrameTest"],
+      "name": "@type must not include a blank node identifier",
+      "purpose": "Node matching does not consider blank nodes.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "frame/0053-in.jsonld",
+      "frame": "frame/0053-frame.jsonld",
+      "expect": "invalid frame"
+    }, {
       "@id": "#tg001",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Library framing example with @graph and omitGraph is true.",

--- a/tests/frame/0052-frame.jsonld
+++ b/tests/frame/0052-frame.jsonld
@@ -1,0 +1,4 @@
+{
+  "@context": {"ex": "http://example.org/"},
+  "@id": ["ex:Sub1", "_:Sub2"]
+}

--- a/tests/frame/0052-in.jsonld
+++ b/tests/frame/0052-in.jsonld
@@ -1,0 +1,15 @@
+[
+  {
+    "@context": {"ex": "http://example.org/"},
+    "@id": "ex:Sub1",
+    "@type": "ex:Type1"
+  }, {
+    "@context": { "ex":"http://example.org/"},
+    "@id": "_:Sub2",
+    "@type": "ex:Type2"
+  }, {
+    "@context": { "ex":"http://example.org/"},
+    "@id": "ex:Sub3",
+    "@type": "ex:Type3"
+  }
+]

--- a/tests/frame/0053-frame.jsonld
+++ b/tests/frame/0053-frame.jsonld
@@ -1,0 +1,4 @@
+{
+  "@context": {"ex": "http://example.org/"},
+  "@id": ["ex:Type1", "_:Type2"]
+}

--- a/tests/frame/0053-in.jsonld
+++ b/tests/frame/0053-in.jsonld
@@ -1,0 +1,15 @@
+[
+  {
+    "@context": {"ex": "http://example.org/"},
+    "@id": "ex:Sub1",
+    "@type": "ex:Type1"
+  }, {
+    "@context": { "ex":"http://example.org/"},
+    "@id": "ex:Sub2",
+    "@type": "ex:Type2"
+  }, {
+    "@context": { "ex":"http://example.org/"},
+    "@id": "ex:Sub3",
+    "@type": "ex:Type3"
+  }
+]


### PR DESCRIPTION
to require that values of `@id` or `@type` within a frame are an empty dictionary or are all valid IRIs.

Adds tests.

Fixes #9.

cc/ @vcharpenay