### PR TITLE
Dfn cleanup

### DIFF
--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -48,7 +48,7 @@
     as a stack with elements from the previous <a>processor state</a>
     copied into a new <a>processor state</a> when entering a new
     <a>JSON object</a>.</dd>
-  <dt><dfn data-lt="promises">promise</dfn></dt><dd>
+  <dt><dfn>promise</dfn></dt><dd>
     A <a data-cite="ECMASCRIPT#sec-promise-objects" class="externalDFN">promise</a> is an object that represents the eventual result of a single asynchronous operation.
     Promises are defined in [[ECMASCRIPT]].</dd>
   <dt><dfn>require all flag</dfn></dt><dd>

--- a/common/terms.html
+++ b/common/terms.html
@@ -1,5 +1,5 @@
 <dl class="termlist" data-sort>
-  <dt><dfn data-lt="arrays">array</dfn></dt><dd>
+  <dt><dfn>array</dfn></dt><dd>
     In the JSON serialization, an array structure is represented as square brackets surrounding zero
     or more values. Values are separated by commas.
     In the <a>internal representation</a>, an array is an <em>ordered</em> collection of zero or more values.
@@ -9,14 +9,14 @@
     unless specifically defined (see
     <a data-cite="JSON-LD11#sets-and-lists" class="externalDFN">Sets and Lists</a> in
     the JSON-LD Syntax specification [[JSON-LD11]]).</dd>
-  <dt><dfn data-lt="JSON objects">JSON object</dfn></dt><dd>
+  <dt><dfn>JSON object</dfn></dt><dd>
     In the JSON serialization, an <a data-cite="RFC8259#section-4" class="externalDFN">object</a> structure is represented as a pair of curly brackets surrounding zero or
     more members composed of name-value pairs. A name is a <a>string</a>. A single colon comes after
     each name, separating the name from the value. A single comma separates a value
     from a following name. In JSON-LD the names in an object MUST be unique.
     In the <a>internal representation</a> a <a>JSON object</a> is equivalent to a
-    <dfn data-cite="WEBIDL#dfn-dictionary" data-lt="dictionaries" class="preserve">dictionary</dfn> (see [[!WEBIDL]]),
-    composed of <dfn data-cite="WEBIDL#dfn-dictionary-member" data-lt="dictionary member|member|members" class="preserve">dictionary members</dfn> with key-value pairs.</dd>
+    <dfn data-cite="WEBIDL#dfn-dictionary" class="preserve">dictionary</dfn> (see [[WEBIDL]]),
+    composed of <dfn data-cite="WEBIDL#dfn-dictionary-member" data-lt="dictionary member|member" class="preserve">dictionary members</dfn> with key-value pairs.</dd>
   <dt class="changed"><dfn data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">The JSON-LD
     internal representation is the result of transforming a JSON syntactic structure
     into the core data structures suitable for direct processing:
@@ -32,55 +32,55 @@
     <code>@value</code>, <code>@list</code>, or <code>@set</code> is set to
     <code>null</code> in expanded form, then the entire <a>JSON
     object</a> is ignored.</dd>
-  <dt><dfn data-lt="numbers|JSON number|JSON numbers">number</dfn></dt><dd>
+  <dt><dfn data-lt="number|JSON number">number</dfn></dt><dd>
     In the JSON serialization, a <a data-cite="RFC8259#section-6" class="externalDFN">number</a> is similar to that used in most programming languages, except
     that the octal and hexadecimal formats are not used and that leading
     zeros are not allowed.
     In the <a>internal representation</a>, a <a>number</a> is equivalent to either
     a <dfn data-cite="WEBIDL#idl-long" class="preserve">long</dfn>
     or <dfn data-cite="WEBIDL#idl-double" class="preserve">double</dfn>, depending
-    on if the number has a non-zero fractional part (see [[!WEBIDL]]).</dd>
+    on if the number has a non-zero fractional part (see [[WEBIDL]]).</dd>
   <dt><dfn>scalar</dfn></dt><dd>
     A scalar is either a JSON <a>string</a>, <a>number</a>, <a>true</a>,
     or <a>false</a>.</dd>
-  <dt><dfn data-lt="strings">string</dfn></dt><dd>
+  <dt><dfn>string</dfn></dt><dd>
     A <a data-cite="RFC8259#section-7" class="externalDFN">string</a> is a sequence of zero or more Unicode (UTF-8) characters,
     wrapped in double quotes, using backslash escapes (if necessary). A
     character is represented as a single character string.</dd>
   <dt><dfn>true</dfn> and <dfn>false</dfn></dt><dd>
     <a data-cite="RFC8259#section-3" class="externalDFN">Values</a> that are used to express one of two possible
-    <dfn data-cite="WEBIDL#idl-boolean" data-lt="booleans" class="preserve">boolean</dfn> states.</dd>
+    <dfn data-cite="WEBIDL#idl-boolean" class="preserve">boolean</dfn> states.</dd>
 </dl>
 
 <p>Furthermore, the following terminology is used throughout this document:</p>
 
 <dl class="termlist" data-sort>
-  <dt><dfn data-lt="absolute IRIs">absolute IRI</dfn></dt><dd>
-    An <a data-cite="RFC3987#section-1.3" class="externalDFN">absolute IRI</a> is defined in [[!RFC3987]] containing a <em>scheme</em> along with a <em>path</em> and
+  <dt><dfn>absolute IRI</dfn></dt><dd>
+    An <a data-cite="RFC3987#section-1.3" class="externalDFN">absolute IRI</a> is defined in [[RFC3987]] containing a <em>scheme</em> along with a <em>path</em> and
     optional <em>query</em> and fragment segments.</dd>
   <dt><dfn>active context</dfn></dt><dd>
     A <a>context</a> that is used to resolve <a>terms</a> while the processing
     algorithm is running.</dd>
-  <dt><dfn data-lt="base IRIs">base IRI</dfn></dt><dd>
+  <dt><dfn>base IRI</dfn></dt><dd>
     The <a>base IRI</a> is an <a>absolute IRI</a> established in the <a>context</a>,
     or is based on the <a>JSON-LD document</a> location. The <a>base IRI</a> is used to turn
     <a>relative IRIs</a> into <a>absolute IRIs</a>.</dd>
-  <dt><dfn data-lt="blank nodes">blank node</dfn></dt><dd>
+  <dt><dfn>blank node</dfn></dt><dd>
     A <a>node</a> in a <a>graph</a> that is neither an
     <a>IRI</a>, nor a <a>JSON-LD value</a>, nor a <a>list</a>.
     A <a data-cite="RDF11-CONCEPTS#dfn-blank-node" class="externalDFN">blank node</a> does not contain a de-referenceable
     identifier because it is either ephemeral in nature or does not contain information that needs to be
     linked to from outside of the <a>linked data graph</a>. A blank node is assigned an identifier starting with
     the prefix <code>_:</code>.</dd>
-  <dt><dfn data-lt="blank node identifiers">blank node identifier</dfn></dt><dd>
+  <dt><dfn>blank node identifier</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-blank-node-identifier" class="externalDFN">blank node identifier</a> is a string that can be used as an identifier for a
     <a>blank node</a> within the scope of a JSON-LD document. Blank node identifiers
     begin with <code>_:</code>.</dd>
-  <dt><dfn data-lt="compact iris">compact IRI</dfn></dt><dd>
+  <dt><dfn>compact IRI</dfn></dt><dd>
     A compact IRI is has the form of <a>prefix</a>:<em>suffix</em> and is used as a way
     of expressing an <a>IRI</a> without needing to define separate <a>term</a> definitions for
     each IRI contained within a common vocabulary identified by <a>prefix</a>.</dd>
-  <dt><dfn data-lt="contexts">context</dfn></dt><dd>
+  <dt><dfn>context</dfn></dt><dd>
     A set of rules for interpreting a <a>JSON-LD document</a> as specified in
     <a data-cite="JSON-LD11#the-context">The Context</a> of the JSON-LD Syntax specification [[JSON-LD11]].</dd>
   <dt><dfn>datatype IRI</dfn></dt><dd>
@@ -92,49 +92,49 @@
     if a <a>named graph</a> is not specified.</dd>
   <dt><dfn>default language</dfn></dt><dd>
     The default language is set in the <a>context</a> using the <code>@language</code> key whose
-    value MUST be a <a>string</a> representing a [[!BCP47]] language code or <code>null</code>.</dd>
+    value MUST be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
   <dt><dfn>default object</dfn></dt><dd>
     A <a>default object</a> is a <a>dictionary</a> that has a <code>@default</code> key.</dd>
-  <dt><dfn data-lt="edges">edge</dfn></dt><dd>
+  <dt><dfn>edge</dfn></dt><dd>
     Every <a>edge</a> has a direction associated with it and is labeled with
     an <a>IRI</a> or a <a>blank node identifier</a>. Within the JSON-LD syntax
     these edge labels are called <a>properties</a>. Whenever possible, an
     <a>edge</a> should be labeled with an <a>IRI</a>.</dd>
-  <dt><dfn data-lt="expanded term definitions">expanded term definition</dfn></dt><dd>
+  <dt><dfn>expanded term definition</dfn></dt><dd>
     An expanded term definition, is a <a>term definition</a> where the value is a <a>dictionary</a>
     containing one or more <a>keyword</a> keys to define the associated <a>absolute IRI</a>,
     if this is a reverse property, the type associated with string values, and a container mapping.</dd>
-  <dt><dfn data-lt="JSON-LD frame|frames">frame</dfn></dt><dd>
+  <dt><dfn data-lt="frame|JSON-LD frame">frame</dfn></dt><dd>
     A <a>JSON-LD document</a>, which describes the form for transforming
     another <a>JSON-LD document</a> using matching and embedding rules.
     A frame document allows additional keywords and certain <a>dictionary members</a>
     to describe the matching and transforming process.</dd>
-  <dt><dfn data-lt="JSON-LD Processors|Processors">JSON-LD Processor</dfn></dt><dd>
+  <dt><dfn data-lt="json-ld processor|Processors">JSON-LD Processor</dfn></dt><dd>
     A <a>JSON-LD Processor</a> is a system which can perform the algorithms defined in [[JSON-LD11-API]].</dd>
   <dt><dfn>frame object</dfn></dt><dd>
     A frame object is a <a>dictionary</a> element within a <a>frame</a>
     which represents a specific portion of the <a>frame</a> matching either a
     <a>node object</a> or a <a>value object</a> in the input.</dd>
-  <dt><dfn data-lt="graph names">graph name</dfn></dt><dd>
+  <dt><dfn>graph name</dfn></dt><dd>
     The <a>IRI</a> identifying a <a data-cite="RDF11-CONCEPTS#dfn-graph-name" class="externalDFN">named graph</a>.</dd>
-  <dt class="changed"><dfn data-lt="id maps">id map</dfn></dt><dd class="changed">
+  <dt class="changed"><dfn>id map</dfn></dt><dd class="changed">
     An <a>id map</a> is a <a>dictionary</a> value of a <a>term</a> defined with
     <code>@container</code> set to <code>@id</code>, whose keys are
     interpreted as <a>IRIs</a> representing the <code>@id</code>
     of the associated <a>node object</a>; value MUST be a <a>node object</a>.
     If the value contains a key expanding to <code>@id</code>, it's value MUST
     be equivalent to the referencing key.</dd>
-  <dt class="changed"><dfn data-lt="graph objects">graph object</dfn></dt><dd class="changed">
+  <dt class="changed"><dfn>graph object</dfn></dt><dd class="changed">
     A <a>graph object</a> represents a <a>named graph</a> represented as the
     value of a <a>dictionary member</a> within a <a>node object</a>. When expanded, a
     graph object MUST have an <code>@graph</code> <a>member</a>, and may also have
     <code>@id</code>, and <code>@index</code> <a>members</a>.
-    A <dfn class="preserve" data-lt="simple graph objects">simple graph object</dfn> is a
+    A <dfn class="preserve">simple graph object</dfn> is a
     <a>graph object</a> which does not have an <code>@id</code> <a>member</a>. Note
     that <a>node objects</a> may have a <code>@graph</code> member, but are
     not considered <a>graph objects</a> if they include any other <a>members</a>.
     A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.</dd>
- <dt><dfn data-lt="index maps">index map</dfn></dt><dd>
+ <dt><dfn>index map</dfn></dt><dd>
   An <a>index map</a> is a <a>dictionary</a> value of a <a>term</a> defined with
   <code>@container</code> set to <code>@index</code>, whose values MUST be any of the following types:
     <a>string</a>,
@@ -148,71 +148,71 @@
     <a>set object</a>, or
     an <a>array</a> of zero or more of the above possibilities.
   </dd>
-  <dt><dfn data-lt="IRIs|Internationalized Resource Identifier"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
-    An <a data-cite="RFC3987#section-1.3" class="externalDFN">Internationalized Resource Identifier</a> as described in [[!RFC3987]].</dd>
-  <dt><dfn data-lt="JSON-LD documents">JSON-LD document</dfn></dt><dd>
+  <dt><dfn data-lt="IRI|Internationalized Resource Identifier"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
+    An <a data-cite="RFC3987#section-1.3" class="externalDFN">Internationalized Resource Identifier</a> as described in [[RFC3987]].</dd>
+  <dt><dfn>JSON-LD document</dfn></dt><dd>
     A <a>JSON-LD document</a> is a serialization of a collection of
     <a>graphs</a> and comprises exactly one
     <a>default graph</a> and zero or more <a>named graphs</a>.</dd>
-  <dt><dfn data-lt="JSON-LD values">JSON-LD value</dfn></dt><dd>
-    A <a data-lt="JSON-LD values">JSON-LD value</a> is a <a>string</a>, a <a>number</a>,
+  <dt><dfn>JSON-LD value</dfn></dt><dd>
+    A <a>JSON-LD value</a> is a <a>string</a>, a <a>number</a>,
     <a>true</a> or <a>false</a>, a <a>typed value</a>, or a
     <a>language-tagged string</a>.</dd>
-  <dt><dfn data-lt="keywords">keyword</dfn></dt><dd>
+  <dt><dfn>keyword</dfn></dt><dd>
     A <a>string</a> that is specific to JSON-LD, specified in the JSON-LD Syntax specification [[JSON-LD11]]
     in the section titled <a data-cite="JSON-LD11#syntax-tokens-and-keywords">Syntax Tokens and Keywords</a>.</dd>
-  <dt><dfn data-lt="language maps">language map</dfn></dt><dd>
+  <dt><dfn>language map</dfn></dt><dd>
     An <a>language map</a> is a <a>dictionary</a> value of a <a>term</a> defined with
     <code>@container</code> set to <code>@language</code>, whose keys MUST be <a>strings</a> representing
-    [[!BCP47]] language codes and the values MUST be any of the following types:
+    [[BCP47]] language codes and the values MUST be any of the following types:
       <a>null</a>,
       <a>string</a>, or
       an <a>array</a> of zero or more of the above possibilities.
     </dd>
-  <dt><dfn data-lt="language-tagged strings">language-tagged string</dfn></dt><dd>
+  <dt><dfn>language-tagged string</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string" class="externalDFN">language-tagged string</a> consists of a string and a non-empty language
-    tag as defined by [[!BCP47]]. The <dfn>language tag</dfn> MUST be well-formed according to
+    tag as defined by [[BCP47]]. The <dfn>language tag</dfn> MUST be well-formed according to
     <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a>
-    of [[!BCP47]], and is normalized to lowercase.</dd>
+    of [[BCP47]], and is normalized to lowercase.</dd>
   <dt><dfn>Linked Data</dfn></dt><dd>
     A set of documents, each containing a representation of a <a>linked data graph</a>.</dd>
-  <dt><dfn data-lt="graph|graphs">linked data graph</dfn></dt><dd>
+  <dt><dfn data-lt="graph">linked data graph</dfn></dt><dd>
     A labeled directed <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph" class="externalDFN">graph</a>, i.e., a set of <a>nodes</a>
     connected by <a>edges</a>,
     as specified in the <a data-cite="JSON-LD11#data-model">Data Model</a>
     section of the JSON-LD specification [[JSON-LD11]].
     A <a>linked data graph</a> is a generalized representation of an
     <dfn class="preserve" data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graph</dfn>
-    as defined in [[!RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-lt="lists">list</dfn></dt><dd>
+    as defined in [[RDF11-CONCEPTS]].</dd>
+  <dt><dfn>list</dfn></dt><dd>
     A <a>list</a> is an ordered sequence of <a>IRIs</a>,
     <a>blank nodes</a>, and <a>JSON-LD values</a>.
     See <dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection" class="preserve">RDF collection</dfn>
-    in [[!RDF-SCHEMA]].</dd>
-  <dt><dfn data-lt="list objects">list object</dfn></dt><dd>
+    in [[RDF-SCHEMA]].</dd>
+  <dt><dfn>list object</dfn></dt><dd>
     A <a>list object</a> is a <a>dictionary</a> that has a <code>@list</code>
     key.</dd>
-  <dt><dfn data-lt="literals">literal</dfn></dt><dd>
+  <dt><dfn>literal</dfn></dt><dd>
     An <a>object</a> expressed as a value such as a string, number or in expanded form.</dd>
-  <dt><dfn data-lt="local contexts">local context</dfn></dt><dd>
+  <dt><dfn>local context</dfn></dt><dd>
     A <a>context</a> that is specified with a <a>dictionary</a>,
     specified via the <code>@context</code> <a>keyword</a>.</dd>
-  <dt><dfn data-lt="named graphs">named graph</dfn></dt><dd>
+  <dt><dfn>named graph</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-named-graph" class="externalDFN">named graph</a> is a <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>.</dd>
-  <dt><dfn data-lt="implicitly named graphs">implicitly named graph</dfn></dt><dd>
+  <dt><dfn>implicitly named graph</dfn></dt><dd>
     A <a>named graph</a> created from the value of a <a>dictionary member</a> having an
     <a>expanded term definition</a> where <code>@container</code> is set to  <code>@graph</code>.</dd>
-  <dt><dfn data-lt="nested properties">nested property</dfn></dt><dd>
+  <dt><dfn>nested property</dfn></dt><dd>
     A <a>nested property</a> is a key in a <a>node object</a> whose value is a
     <a>dictionary</a> containing <a>members</a> which are treated as if they were values of the <a>node object</a>.
     The <a>nested property</a> itself is semantically meaningless used only to create a sub-structure within
     a <a>node object</a>.
   </dd>
-  <dt><dfn data-lt="nodes">node</dfn></dt><dd>
+  <dt><dfn>node</dfn></dt><dd>
     Every <a data-cite="RDF11-CONCEPTS#dfn-node" class="externalDFN">node</a> is an <a>IRI</a>, a <a>blank node</a>,
     a <a>JSON-LD value</a>, or a <a>list</a>.
     A piece of information that is represented in a <a>linked data graph</a>.</dd>
-  <dt><dfn data-lt="node objects">node object</dfn></dt><dd>
+  <dt><dfn>node object</dfn></dt><dd>
     A <a>node object</a> represents zero or more <a>properties</a> of a
     <a>node</a> in the <a>graph</a> serialized by the
     <a>JSON-LD document</a>. A <a>dictionary</a> is a <a>node object</a>
@@ -225,56 +225,56 @@
     </ul>
     The <a>members</a> of a <a>node object</a> whose keys are not keywords are also called <a>properties</a> of the <a>node object</a>.
   </dd>
-  <dt><dfn data-lt="node references">node reference</dfn></dt><dd>
+  <dt><dfn>node reference</dfn></dt><dd>
     A <a>node object</a> used to reference a node having only the
     <code>@id</code> key.</dd>
-  <dt><dfn data-lt="objects">object</dfn></dt><dd>
+  <dt><dfn>object</dfn></dt><dd>
     An <a data-cite="RDF11-CONCEPTS#dfn-object" class="externalDFN">object</a> is a <a>node</a> in a <a>linked data graph</a> with at least one incoming edge.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">RDF object</dfn> in [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-lt="prefixes">prefix</dfn></dt><dd>
+  <dt><dfn>prefix</dfn></dt><dd>
     A <a>prefix</a> is the first component of a <a>compact IRI</a> which comes from a
     <a>term</a> that maps to a string that, when prepended to the suffix of the <a>compact IRI</a>
     results in an <a>absolute IRI</a>.</dd>
   <dt><dfn>processing mode</dfn></dt><dd>
     The processing mode defines how a JSON-LD document is processed.
     By default, all documents are assumed to be conformant with
-    <a data-cite="JSON-LD">JSON-LD 1.0</a> [[!JSON-LD]]. By defining
+    <a data-cite="JSON-LD">JSON-LD 1.0</a> [[JSON-LD]]. By defining
     a different version using the <code>@version</code> <a>member</a> in a
     <a>context</a>, or via explicit API option, other processing modes
     can be accessed. This specification defines extensions for the
     <code>json-ld-1.1</code> <a>processing mode</a>.</dd>
-  <dt><dfn data-lt="properties">property</dfn></dt><dd>
+  <dt><dfn>property</dfn></dt><dd>
     The <a>IRI</a> label of an edge in a <a>linked data graph</a>.
-    See <dfn data-cite="RDF11-CONCEPTS#dfn-predicate" data-lt="predicate|predicates|RDF predicates" class="preserve">RDF predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
-    <dt><dfn data-lt="quads">quad</dfn></dt><dd>
+    See <dfn data-cite="RDF11-CONCEPTS#dfn-predicate" data-lt="predicate" class="preserve">RDF predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
+    <dt><dfn>quad</dfn></dt><dd>
     A piece of information that contains four items; a <a>subject</a>, a <a>property</a>,
     an <a>object</a>, and a <a>graph name</a>.</dd>
-  <dt><dfn data-lt="dataset|datasets">RDF dataset</dfn></dt><dd>
+  <dt><dfn data-lt="dataset">RDF dataset</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" class="externalDFN">dataset</a> as specified by [[RDF11-CONCEPTS]] representing a collection of
     <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graphs</a>.</dd>
   <dt><dfn data-lt="resource">RDF resource</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-resource" class="externalDFN">resource</a> as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-lt="triple|triples|RDF triples">RDF triple</dfn></dt><dd>
+  <dt><dfn data-lt="triple">RDF triple</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-rdf-triple" class="externalDFN">triple</a> as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-lt="relative IRIs">relative IRI</dfn></dt><dd>
+  <dt><dfn>relative IRI</dfn></dt><dd>
     A relative IRI is an <a>IRI</a> that is relative to some other <a>absolute IRI</a>,
     typically the <a>base IRI</a> of the document. Note that
     <a>properties</a>, values of <code>@type</code>, and values of <a>terms</a> defined to be <em>vocabulary relative</em>
     are resolved relative to the <a>vocabulary mapping</a>, not the <a>base IRI</a>.</dd>
   <dt><dfn>set object</dfn></dt><dd>
     A <a>set object</a> is a <a>dictionary</a> that has an <code>@set</code> <a>member</a>.</dd>
-  <dt><dfn data-lt="subjects">subject</dfn></dt><dd>
+  <dt><dfn>subject</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-subject" class="externalDFN">subject</a> is a<a>node</a> in a <a>linked data graph</a> with at least one outgoing edge, related to an <a>object</a> node through a <a>property</a>.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">RDF subject</dfn> in [[RDF11-CONCEPTS]].</dd>
-    <dt><dfn data-lt="terms">term</dfn></dt><dd>
+    <dt><dfn>term</dfn></dt><dd>
     A <a>term</a> is a short word defined in a <a>context</a> that MAY be expanded to an <a>IRI</a>
   </dd>
-  <dt><dfn data-lt="term definitions">term definition</dfn></dt><dd>
+  <dt><dfn>term definition</dfn></dt><dd>
     A term definition is an entry in a <a>context</a>, where the key defines a <a>term</a> which may be used within
     a <a>dictionary</a> as a key, type, or elsewhere that a string is interpreted as a vocabulary item.
-    Its value is either a string (<dfn data-lt="simple terms|simple term|simple term definitions">simple term definition</dfn>), expanding to an absolute IRI, or an <a>expanded term definition</a>.
+    Its value is either a string (<dfn data-lt="simple term">simple term definition</dfn>), expanding to an absolute IRI, or an <a>expanded term definition</a>.
   </dd>
-  <dt class="changed"><dfn data-lt="type maps">type map</dfn></dt><dd class="changed">
+  <dt class="changed"><dfn>type map</dfn></dt><dd class="changed">
     An <a>type map</a> is a <a>dictionary</a> value of a <a>term</a> defined with
     <code>@container</code> set to <code>@type</code>, whose keys are
     interpreted as <a>IRIs</a> representing the <code>@type</code>
@@ -285,11 +285,11 @@
   <dt><dfn>typed literal</dfn></dt><dd>
     A <a>typed literal</a> is a <a>literal</a> with an associated <a>IRI</a>
     which indicates the literal's datatype.
-    See <dfn data-cite="RDF11-CONCEPTS#dfn-literal" data-lt="RDF literals" class="preserve">RDF literal</dfn> in [[!RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-lt="typed values">typed value</dfn></dt><dd>
+    See <dfn data-cite="RDF11-CONCEPTS#dfn-literal" class="preserve">RDF literal</dfn> in [[RDF11-CONCEPTS]].</dd>
+  <dt><dfn>typed value</dfn></dt><dd>
     A <a>typed value</a> consists of a value, which is a <a>string</a>, and a type,
     which is an <a>IRI</a>.</dd>
-  <dt><dfn data-lt="value objects">value object</dfn></dt><dd>
+  <dt><dfn>value object</dfn></dt><dd>
     A <a>value object</a> is a <a>dictionary</a> that has an <code>@value</code> <a>member</a>.</dd>
   <dt><dfn>vocabulary mapping</dfn></dt><dd>
     The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key whose

--- a/index.html
+++ b/index.html
@@ -24,9 +24,9 @@
 
       // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
       // and its maturity status
-      prevVersion:            "https://www.w3.org/TR/2018/WD-json-ld11-framing-20180911/",
-      previousPublishDate:    "2018-09-11",
-      previousMaturity:       "FPWD",
+      prevVersion:            "https://www.w3.org/TR/2018/WD-json-ld11-framing-20181012/",
+      previousPublishDate:    "2018-10-12",
+      previousMaturity:       "WD",
       github:                 "https://github.com/w3c/json-ld-framing/",
 
       // if there a publicly available Editor's Draft, this is the link
@@ -43,6 +43,7 @@
       includePermalinks:    true,
       doJsonLd:             true,
       highlightVars:        true,
+      pluralize:              true,
 
       // editors, add as many as you like
       // only "name" is required
@@ -308,14 +309,14 @@ Data in JSON. The document is primarily intended for the following audiences:
 
 <p>
 To understand the basics in this specification you must first be familiar with
-<a data-cite="RFC8259">JSON</a>, which is detailed in [[!RFC8259]]. You must also understand the
-JSON-LD 1.1 Syntax specification [[!JSON-LD11]], which is the base syntax used by all of the
+<a data-cite="RFC8259">JSON</a>, which is detailed in [[RFC8259]]. You must also understand the
+JSON-LD 1.1 Syntax specification [[JSON-LD11]], which is the base syntax used by all of the
 algorithms in this document,
-and the JSON-LD 1.1 API [[!JSON-LD11-API]]. To understand the API and how it is
+and the JSON-LD 1.1 API [[JSON-LD11-API]]. To understand the API and how it is
 intended to operate  in a programming environment, it is useful to have working
 knowledge of the JavaScript programming language [[ECMASCRIPT]] and
-WebIDL [[!WEBIDL]]. To understand how JSON-LD maps to RDF, it is helpful to be
-familiar with the basic RDF concepts [[!RDF11-CONCEPTS]].</p>
+WebIDL [[WEBIDL]]. To understand how JSON-LD maps to RDF, it is helpful to be
+familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
 
 </section>
 
@@ -346,8 +347,8 @@ familiar with the basic RDF concepts [[!RDF11-CONCEPTS]].</p>
 <section>
     <h2>Terminology</h2>
 
-    <p>This document uses the following terms as defined in JSON [[!RFC8259]]. Refer
-      to the <a data-cite="RFC8259#section-2">JSON Grammar section</a> in [[!RFC8259]] for formal definitions.</p>
+    <p>This document uses the following terms as defined in JSON [[RFC8259]]. Refer
+      to the <a data-cite="RFC8259#section-2">JSON Grammar section</a> in [[RFC8259]] for formal definitions.</p>
 
     <div data-include="common/terms.html"
          data-oninclude="restrictReferences">
@@ -1016,7 +1017,7 @@ familiar with the basic RDF concepts [[!RDF11-CONCEPTS]].</p>
   <h2>Syntax Tokens and Keywords</h2>
 
   <p>This specification adds a number of <a>keywords</a> (<dfn>framing keywords</dfn>) to
-    the ones defined in the JSON-LD 1.1 Syntax specification [[!JSON-LD11]]:</p>
+    the ones defined in the JSON-LD 1.1 Syntax specification [[JSON-LD11]]:</p>
 
   <dl data-sort>
     <dt><code>@default</code></dt>
@@ -1457,7 +1458,7 @@ familiar with the basic RDF concepts [[!RDF11-CONCEPTS]].</p>
 
     <p>The <a data-cite="JSON-LD11-API#dfn-json-ld-processors">JSON-LD Processor</a> interface is the high-level programming structure that developers
       use to access the JSON-LD transformation methods. The definition below is an experimental
-      extension of the interface defined in the JSON-LD 1.1 API [[!JSON-LD11-API]].</p>
+      extension of the interface defined in the JSON-LD 1.1 API [[JSON-LD11-API]].</p>
 
     <pre class="idl" data-transform="unComment"><!--
       [Constructor]
@@ -1574,7 +1575,7 @@ familiar with the basic RDF concepts [[!RDF11-CONCEPTS]].</p>
         <a>IRI</a>, or an array of <a class="changed">dictionaries</a>
         and <a>strings</a>.</p>
 
-    <p>See <a data-cite="JSON-LD11-API#dom-jsonldcontext">JsonLdContext</a> definition in the JSON-LD 1.1 API [[!JSON-LD11-API]].</p>
+    <p>See <a data-cite="JSON-LD11-API#dom-jsonldcontext">JsonLdContext</a> definition in the JSON-LD 1.1 API [[JSON-LD11-API]].</p>
     </section>
 
     <section>
@@ -1648,7 +1649,7 @@ familiar with the basic RDF concepts [[!RDF11-CONCEPTS]].</p>
         Always use a <a>node reference</a> when serializing matching values.</dd>
     </dl>
 
-    <p>See <a data-cite="JSON-LD11-API#dom-jsonldoptions">JsonLdOptions</a> definition in the JSON-LD 1.1 API [[!JSON-LD11-API]].</p>
+    <p>See <a data-cite="JSON-LD11-API#dom-jsonldoptions">JsonLdOptions</a> definition in the JSON-LD 1.1 API [[JSON-LD11-API]].</p>
   </section>
   </section>
 


### PR DESCRIPTION
* Make definition identifiers singular, and use automatic term pluralization.

* Update previous published version.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/25.html" title="Last updated on Oct 12, 2018, 9:24 PM GMT (c6965d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/25/ae94e0a...c6965d7.html" title="Last updated on Oct 12, 2018, 9:24 PM GMT (c6965d7)">Diff</a>