### PR TITLE
Add note on asymmetry of reverse properties in frames.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/ruby-rdf/json-ld.git
-  revision: b74e49d3ecfc9e139ea3c60c0f700e9d2d844b20
+  revision: d4556f730a9b97a739d9d30f601b8e8ddbe55cd4
   branch: develop
   specs:
     json-ld (3.0.2)
@@ -29,7 +29,7 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     htmlentities (4.3.4)
-    i18n (1.1.0)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     json-ld-preloaded (3.0.1)
       json-ld (~> 3.0)
@@ -77,7 +77,7 @@ GEM
       nokogiri
     public_suffix (3.0.3)
     rake (12.3.1)
-    rdf (3.0.4)
+    rdf (3.0.5)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (2.2.1)
@@ -166,4 +166,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/index.html
+++ b/index.html
@@ -797,7 +797,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
     </section>
   </section>
 
-  <section class="informative">
+  <section class="informative changed">
     <h3>Reverse Framing</h3>
     <p>A frame may include <code>@reverse</code>, or a value of a term defined using <code>@reverse</code>
       to invert the relationships in the output object. For example, the
@@ -867,6 +867,16 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
       -->
       </pre>
     </aside>
+
+    <div class="note">
+      <p>There is an asymmetry between regular properties and reverse properties.
+        Normally, when framing a <a>node object</a>, unless the <a>explicit inclusion flag</a> is set,
+        all properties of the node are included in the output, but reverse
+        properties are not, as they are not actually properties of the node.</p>
+      <p>To include reverse properties in the output, add them explicitly to the frame.
+        Note that if the reverse relationship does not exist, it will simply be
+        left out of the output.</p>
+    </div>
   </section>
 
   <section class="informative changed">
@@ -1730,8 +1740,6 @@ becomes a W3C Recommendation.</p>
 <section class="appendix informative preserve">
   <h4>Open Issues</h4>
   <p>The following is a list of issues open at the time of publication.</p>
-  <p class="issue" data-number="5">It would be nice to have the same possiblity of infinite recursion in the @reverse properties as there are in non-reverse ones, currently recursion only works as many times as the frame defines it.</p>
-  <p class="issue" data-number="9">Clarification required on the use of blank node identifiers in frames.</p>
 </section>
 
 <section class="appendix informative">
@@ -1770,10 +1778,13 @@ becomes a W3C Recommendation.</p>
       <a data-link-for="JsonLdOptions">omitDefault</a> API option and/or
       the current <a>processing mode</a>.</li>
     <li>The API now adds an <a data-link-for="JsonLdOptions">ordered</a>
-       option, defaulting to <code>false</code> This is used in algorithms to
-       control interation of <a>dictionary member</a> keys. Previously, the
-       algorithms always required such an order. The instructions for
-       evaluating test results have been updated accordingly.</li>
+      option, defaulting to <code>false</code> This is used in algorithms to
+      control interation of <a>dictionary member</a> keys. Previously, the
+      algorithms always required such an order. The instructions for
+      evaluating test results have been updated accordingly.</li>
+    <li>Frames may include reverse properties using <code>@reverse</code>, or a term
+      defined with <code>@reverse</code>, which can cause nodes referencing a
+      node targeted by a frame to have a reverse reference created.</li>
   </ul>
 </section>
 


### PR DESCRIPTION
Fixes #5.

cc/ @eroux


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/26.html" title="Last updated on Oct 15, 2018, 6:12 PM GMT (4bc64a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/26/912017b...4bc64a3.html" title="Last updated on Oct 15, 2018, 6:12 PM GMT (4bc64a3)">Diff</a>