### PR TITLE
Improve the introduction

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: git://github.com/ruby-rdf/json-ld.git
-  revision: d4556f730a9b97a739d9d30f601b8e8ddbe55cd4
+  revision: 7717390f78fea8152f9d82a1d52f3695dd36575e
   branch: develop
   specs:
     json-ld (3.0.2)
-      multi_json (~> 1.12)
-      rdf (>= 2.2.8, < 4.0)
+      multi_json (~> 1.13)
+      rack (>= 1.6, < 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -16,7 +16,7 @@ GEM
       i18n
     builder (3.2.3)
     colorize (0.8.1)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     connection_pool (2.2.2)
     ebnf (1.1.3)
       rdf (~> 3.0)
@@ -29,9 +29,9 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     htmlentities (4.3.4)
-    i18n (1.1.1)
+    i18n (1.4.0)
       concurrent-ruby (~> 1.0)
-    json-ld-preloaded (3.0.1)
+    json-ld-preloaded (3.0.2)
       json-ld (~> 3.0)
       multi_json (~> 1.12)
       rdf (~> 3.0)
@@ -67,17 +67,18 @@ GEM
       shex (~> 0.5, >= 0.5.2)
       sparql (~> 3.0)
       sparql-client (~> 3.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     multi_json (1.13.1)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.9.1)
+      mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
     public_suffix (3.0.3)
-    rake (12.3.1)
-    rdf (3.0.5)
+    rack (2.0.6)
+    rake (12.3.2)
+    rdf (3.0.9)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (2.2.1)
@@ -126,7 +127,7 @@ GEM
     rdf-turtle (3.0.3)
       ebnf (~> 1.1)
       rdf (~> 3.0)
-    rdf-vocab (3.0.3)
+    rdf-vocab (3.0.4)
       rdf (~> 3.0)
     rdf-xsd (3.0.1)
       rdf (~> 3.0)
@@ -146,13 +147,13 @@ GEM
       rdf-xsd (~> 3.0)
       sparql-client (~> 3.0)
       sxp (~> 1.0)
-    sparql-client (3.0.0)
+    sparql-client (3.0.1)
       net-http-persistent (>= 2.9, < 4)
       rdf (~> 3.0)
     sxp (1.0.1)
       rdf (>= 2.2, < 4.0)
     temple (0.8.0)
-    tilt (2.0.8)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
@@ -166,4 +167,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/index.html
+++ b/index.html
@@ -266,8 +266,8 @@
 <h1>Introduction</h1>
 <p>JSON-LD is a lightweight syntax to serialize Linked Data [[LINKED-DATA]] in JSON [[RFC8259]].
   Its design allows existing JSON to be interpreted as Linked Data with minimal changes.
-  As with other representations, of Linked Data which describe directed graphs,
-  A single directed graph can have many different serializations, each expressing
+  As with other representations of Linked Data which describe directed graphs,
+  a single directed graph can have many different serializations, each expressing
   exactly the same information. Developers typically work with trees, represented as
   <a>JSON objects</a>. While mapping a graph to
   a tree can be done, the layout of the end result must be specified in advance.


### PR DESCRIPTION
borrowing from the Intro of the Syntax document.

Fixes #32.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/33.html" title="Last updated on Jan 4, 2019, 7:34 PM UTC (a1b8a0b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/33/63e4e99...a1b8a0b.html" title="Last updated on Jan 4, 2019, 7:34 PM UTC (a1b8a0b)">Diff</a>