### PR TITLE
Replace `@first` and `@last` with `@once.

### DIFF
--- a/index.html
+++ b/index.html
@@ -624,13 +624,13 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
         The initial value for the <a>object embed flag</a> is set using the
         <a data-link-for="JsonLdOptions">embed</a> option.
         Consider the following frame
-        based on the default <code>@first</code> value of the <a>object embed flag</a>:</p>
+        based on the default <code>@once</code> value of the <a>object embed flag</a>:</p>
 
-      <pre id="sample-library-frame-with-implicit-embed-set-to-first"
+      <pre id="sample-library-frame-with-implicit-embed-set-to-once"
            class="example frame" data-transform="updateExample"
            data-content-type="application/ld+json;profile=http://www.w3.org/ns/json-ld#framed"
            data-frame-for="Flattened library objects"
-           title="Sample library frame with implicit @embed set to @first">
+           title="Sample library frame with implicit @embed set to @once">
       <!--
       {
         "@context": {"@vocab": "http://example.org/"},
@@ -640,15 +640,15 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
       </pre>
 
       <aside class="example ds-selector-tabs"
-             title="Framed library objects with @embed set to @first">
+             title="Framed library objects with @embed set to @once">
         <div class="selectors">
           <a class="playground"
              data-result-for="#flattened-library-objects"
-             data-frame="#sample-library-frame-with-implicit-embed-set-to-first"
+             data-frame="#sample-library-frame-with-implicit-embed-set-to-once"
              target="_blank"></a>
         </div>
         <pre class="selected original nohighlight" data-transform="updateExample"
-             data-frame="Sample library frame with implicit @embed set to @first"
+             data-frame="Sample library frame with implicit @embed set to @once"
              data-result-for="Flattened library objects">
         <!--
         {
@@ -674,11 +674,12 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
         </pre>
       </aside>
 
-      <p>Because, the default for the <a>object embed flag</a> is <code>@first</code>
+      <p>Because, the default for the <a>object embed flag</a> is <code>@once</code>
          (in addition to the <a>explicit inclusion flag</a> being <code>false</code>),
          non-listed properties are added to the output, and implicitly embedded
          using a default empty frame. As a result, the same output used in the
-         <a href="#lib-example-output">Framed library objects</a> above is generated.</p>
+         <a href="#lib-example-output">Framed library objects</a> above is generated,
+         assuming that the <a data-link-for="JsonLdOptions">ordered</a> flag is <code>true</code>.</p>
 
       <p>However, if the <code>@embed</code> property is added explicitly with a
          value of <code>@never</code>, the values for <em>Book</em> and <em>Chapter</em> will be excluded.</p>
@@ -726,7 +727,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
         </pre>
       </aside>
 
-      <p>To illustrate the case where <code>@first</code> does not expand values,
+      <p>To illustrate the case where <code>@once</code> does not expand values,
         consider an alternate library example where books are doubly indexed.</p>
 
       <pre id="flattened-library-objects-with-double-index"
@@ -765,11 +766,11 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
         <div class="selectors">
           <a class="playground"
              data-result-for="#flattened-library-objects-with-double-index"
-             data-frame="#sample-library-frame-with-implicit-embed-set-to-first"
+             data-frame="#sample-library-frame-with-implicit-embed-set-to-once"
              target="_blank"></a>
         </div>
         <pre class="selected original nohighlight" data-transform="updateExample"
-             data-frame="Sample library frame with implicit @embed set to @first"
+             data-frame="Sample library frame with implicit @embed set to @once"
              data-result-for="Flattened library objects with double index">
         <!--
         {
@@ -796,60 +797,10 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
         </pre>
       </aside>
 
-      <p>When framed using the same frame with the default <code>@embed</code> of <code>@first</code>,
-        only the <em>"books"</em> property will have content, and the <em>"contains"</em> property will use a reference.</p>
-
-      <p>If we use a frame using <code>"@embed": "@last"</code>,
-        only the "contains" property will use a reference.</p>
-
-      <pre id="sample-library-frame-with-explicit-embed-set-to-last"
-           class="example frame nohighlight" data-transform="updateExample"
-           data-content-type="application/ld+json;profile=http://www.w3.org/ns/json-ld#framed"
-           data-frame-for="Flattened library objects with double index"
-           title="Sample library frame with explicit @embed set to @last">
-      <!--
-      {
-        "@context": {"@vocab": "http://example.org/"},
-        "@type": "Library",
-        ****"@embed": "@last"****
-      }
-      -->
-      </pre>
-      <aside class="example ds-selector-tabs"
-             title="Framed library objects with double index and @last">
-        <div class="selectors">
-          <a class="playground"
-             data-result-for="#flattened-library-objects-with-double-index"
-             data-frame="#sample-library-frame-with-explicit-embed-set-to-last"
-             target="_blank"></a>
-        </div>
-        <pre class="selected original nohighlight" data-transform="updateExample"
-             data-frame="Sample library frame with explicit @embed set to @last"
-             data-result-for="Flattened library objects with double index">
-        <!--
-        {
-          "@context": {"@vocab": "http://example.org/"},
-          "@graph": [{
-            "@id": "http://example.org/library",
-            "@type": "Library",
-            ****"books": {"@id": "http://example.org/library/the-republic"},****
-            ****"contains": {
-              "@id": "http://example.org/library/the-republic",
-              "@type": "Book",
-              "contains": {
-                "@id": "http://example.org/library/the-republic#introduction",
-                "@type": "Chapter",
-                "description": "An introductory chapter on The Republic.",
-                "title": "The Introduction"
-              },
-              "creator": "Plato",
-              "title": "The Republic"
-            }****
-          }]
-        }
-       -->
-        </pre>
-      </aside>
+      <p>When framed using the same frame with the default <code>@embed</code> of <code>@once</code>,
+        only the <em>"books"</em> property will have content,
+        if the <a data-link-for="JsonLdOptions">ordered</a> flag is <code>true</code>,
+        and the <em>"contains"</em> property will use a reference.</p>
 
       <p>If we use a frame using <code>"@embed": "@always"</code>,
         both properties will include expanded values.</p>
@@ -1431,15 +1382,15 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
           Always embed <a>node objects</a> as property values, unless this would
           cause a circular reference.
         </dd>
-        <dt class="changed"><code>@first</code></dt><dd class="changed">
-          Only the first value within a given <a>node object</a> should be embedded,
-          subsequent values of other properties use a <a>node reference</a>. This is the
+        <dt class="changed"><code>@once</code></dt><dd class="changed">
+          Juse a single value within a given <a>node object</a> should be embedded,
+          other values of other properties use a <a>node reference</a>. This is the
           default value if neither <code>@embed</code> nor <a>object embed flag</a>
           is not specified.
-        </dd>
-        <dt><code>@last</code></dt><dd>
-          Only the last value within a given <a>node object</a> should be embedded,
-          previous values of other properties use a <a>node reference</a>.
+          <div class="note">The specific <a>node object</a> chosen to embed depends on
+            ordering. if the <a data-link-for="JsonLdOptions">ordered</a> flag is <code>true</code>,
+            this will be the first <a>node object</a> encountered,
+            otherwise, it may be any node object.</div>
         </dd>
         <dt><code>@never</code></dt><dd>
           Always use a <a>node reference</a> when serializing matching values.
@@ -1536,7 +1487,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
 
 <p>The recursive algorithm operates with a <a>framing state</a> (<var>state</var>),
   created initially using
-  the <a>object embed flag</a> set to <code>@first</code>,
+  the <a>object embed flag</a> set to <code>@once</code>,
   the <a>explicit inclusion flag</a> set to <code>false</code>,
   the <a>require all flag</a> set to <code>true</code>,
   the <a>omit default flag</a> set to <code>false</code>,
@@ -1583,18 +1534,11 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
         circular reference would be created by an embed,
         add <var>output</var> to <var>parent</var>
         and do not perform additional processing for this <var>node</var>.</li>
-      <li class="changed">Otherwise, if <var>embed</var> is <code>@first</code>
+      <li class="changed">Otherwise, if <var>embed</var> is <code>@once</code>
         and parent has an existing embedded node in <var>parent</var> associated with
         <var>graph name</var> and <var>id</var> in <var>state</var>,
         add <var>output</var> to <var>parent</var>
-        and do not perform additional processing for this <var>node</var>.
-        <span class="ednote">Requires sorting of subjects.
-          We could consider <code>@sample</code>, to embed in a property, rather than the lexicographically first.</span></li>
-      <li>Otherwise, if <var>embed</var> is <code>@last</code>,
-        remove any existing embedded node from <var>parent</var> associated with
-        <var>graph name</var> and <var>id</var> in <var>state</var>.
-        <span class="ednote">Requires sorting of subjects.
-          We could consider <code>@sample</code>, to embed in a property, rather than the lexicographically last.</span></li>
+        and do not perform additional processing for this <var>node</var>.</li>
       <li class="changed">If <var>graph map</var> in <var>state</var> has an entry for <var>id</var>:
         <ol>
           <li>If <var>frame</var> does not have a <code>@graph</code> <a>member</a>,
@@ -1989,19 +1933,18 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
 
     <pre class="idl" data-transform="unComment"><!--
       dictionary JsonLdOptions {
-        (JsonLdEmbed or boolean)  embed = "@first";
-        boolean                   explicit    = false;
-        boolean                   omitDefault = false;
+        (JsonLdEmbed or boolean)  embed         = "@once";
+        boolean                   explicit      = false;
+        boolean                   omitDefault   = false;
         boolean                   omitGraph;
-        boolean                   requireAll  = false;
+        boolean                   requireAll    = false;
         boolean                   frameDefault  = false;
-        boolean                   ordered = false;
+        boolean                   ordered       = false;
       };
 
       enum JsonLdEmbed {
         "@always",
-        "@first",
-        "@last",
+        "@once",
         "@never"
       };
     -->
@@ -2015,7 +1958,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
       <dd>Sets the value <a>object embed flag</a> used in the
         <a href="#framing-algorithm">Framing Algorithm</a>.
         A boolean value of <code>true</code> sets the flag to
-        <code>@last</code>, while an value of <code>false</code> sets the flag
+        <code>@once</code>, while an value of <code>false</code> sets the flag
         to <code>@never</code>.</dd>
       <dt><dfn data-dfn-for="JsonLdOptions">explicit</dfn></dt>
       <dd>Sets the value <a>explicit inclusion flag</a> used in the
@@ -2045,14 +1988,11 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
       <dt><dfn data-dfn-for="JsonLdEmbed">@always</dfn></dt><dd>
         Always embed <a>node objects</a> as property values, unless this would
         cause a circular reference.</dd>
-      <dt><dfn data-dfn-for="JsonLdEmbed">@first</dfn></dt><dd>
-        Only the first value within a given <a>node object</a> should be embedded,
-        subsequent values of other properties use a <a>node reference</a>. This is the
+      <dt><dfn data-dfn-for="JsonLdEmbed">@once</dfn></dt><dd>
+        Only a single value within a given <a>node object</a> should be embedded,
+        other values of other properties use a <a>node reference</a>. This is the
         default value if neither <code>@embed</code> nor <a>object embed flag</a>
         is not specified.</dd>
-      <dt><dfn data-dfn-for="JsonLdEmbed">@last</dfn></dt><dd>
-        Only the last value within a given <a>node object</a> should be embedded,
-        previous values of other properties use a <a>node reference</a>.</dd>
       <dt class="changed"><dfn data-dfn-for="JsonLdEmbed">@never</dfn></dt><dd class="changed">
         Always use a <a>node reference</a> when serializing matching values.</dd>
     </dl>
@@ -2238,6 +2178,8 @@ becomes a W3C Recommendation.</p>
       evaluating test results have been updated accordingly.</li>
     <li>The IANA registration is changed from <code>application/ld-frame+json</code> to
       <code>application/ld+json</code> with a required <code>profile</code> parameter.</li>
+    <li>Removed <code>@first</code> and <code>@last</code> values for the
+      <a>object embed flag</a> in favor of <code>@once</code>.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -1383,7 +1383,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
           cause a circular reference.
         </dd>
         <dt class="changed"><code>@once</code></dt><dd class="changed">
-          Juse a single value within a given <a>node object</a> should be embedded,
+          Just a single value within a given <a>node object</a> should be embedded,
           other values of other properties use a <a>node reference</a>. This is the
           default value if neither <code>@embed</code> nor <a>object embed flag</a>
           is not specified.

--- a/index.html
+++ b/index.html
@@ -1992,7 +1992,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
         Only a single value within a given <a>node object</a> should be embedded,
         other values of other properties use a <a>node reference</a>. This is the
         default value if neither <code>@embed</code> nor <a>object embed flag</a>
-        is not specified.</dd>
+        is specified.</dd>
       <dt class="changed"><dfn data-dfn-for="JsonLdEmbed">@never</dfn></dt><dd class="changed">
         Always use a <a>node reference</a> when serializing matching values.</dd>
     </dl>

--- a/index.html
+++ b/index.html
@@ -1958,7 +1958,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
       <dd>Sets the value <a>object embed flag</a> used in the
         <a href="#framing-algorithm">Framing Algorithm</a>.
         A boolean value of <code>true</code> sets the flag to
-        <code>@once</code>, while an value of <code>false</code> sets the flag
+        <code>@once</code>, while a value of <code>false</code> sets the flag
         to <code>@never</code>.</dd>
       <dt><dfn data-dfn-for="JsonLdOptions">explicit</dfn></dt>
       <dd>Sets the value <a>explicit inclusion flag</a> used in the

--- a/index.html
+++ b/index.html
@@ -1386,7 +1386,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
           Just a single value within a given <a>node object</a> should be embedded,
           other values of other properties use a <a>node reference</a>. This is the
           default value if neither <code>@embed</code> nor <a>object embed flag</a>
-          is not specified.
+          is specified.
           <div class="note">The specific <a>node object</a> chosen to embed depends on
             ordering. if the <a data-link-for="JsonLdOptions">ordered</a> flag is <code>true</code>,
             this will be the first <a>node object</a> encountered,

--- a/index.html
+++ b/index.html
@@ -1388,7 +1388,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
           default value if neither <code>@embed</code> nor <a>object embed flag</a>
           is specified.
           <div class="note">The specific <a>node object</a> chosen to embed depends on
-            ordering. if the <a data-link-for="JsonLdOptions">ordered</a> flag is <code>true</code>,
+            ordering. If the <a data-link-for="JsonLdOptions">ordered</a> flag is <code>true</code>,
             this will be the first <a>node object</a> encountered,
             otherwise, it may be any node object.</div>
         </dd>

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,6 +35,7 @@ Implementations create their own infrastructure for running the test suite. In p
 
 * Some algorithms, may not preserve the order of statements listed in the input document, and provision should be taken for performing unordered array comparison, for arrays other than values of `@list`. (This may be difficult for compacted results, where array value ordering is dependent on the associated term definition).
 * Some implementations may choose an alternative Blank Node Label algorithm, the comparison between documents containing blank node labels should take this into consideration. (One way to do this may be to reduce both results and _expected_ to datsets to extract a bijective mapping of blank node labels between the two datasets as described in [RDF Dataset Isomorphism](https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism)).
+* Note that the `"@embed": "@once"` test behavior requires that the `ordered` option be set to `true` for repeatability.
 
 # Contributing
 

--- a/tests/frame-manifest.jsonld
+++ b/tests/frame-manifest.jsonld
@@ -82,7 +82,7 @@
       "@id": "#t0010",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "property CURIE conflict",
-      "purpose": "(Not really framing) A term looking like a CURIE becomes a CURIE when framing/compacting if defined as such in frame/context.",
+      "purpose": "(Not really framing) A term looking like a CURIE becomes a CURIE when framing/compacting if defined as such in frame/context in json-ld-1.0 mode.",
       "input": "frame/0010-in.jsonld",
       "frame": "frame/0010-frame.jsonld",
       "expect": "frame/0010-out.jsonld",
@@ -90,11 +90,12 @@
     }, {
       "@id": "#t0011",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
-      "name": "@embed",
-      "purpose": "@embed within a frame controls the object embed flag when processing that frame (true and false values).",
+      "name": "@embed true/false",
+      "purpose": "@embed within a frame controls the object embed flag when processing that frame (true and false values) in json-ld-1.0 mode.",
       "input": "frame/0011-in.jsonld",
       "frame": "frame/0011-frame.jsonld",
-      "expect": "frame/0011-out.jsonld"
+      "expect": "frame/0011-out.jsonld",
+      "options": {"spec-version": "json-ld-1.1", "processingMode": "json-ld-1.0"}
     }, {
       "@id": "#t0012",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -163,7 +164,7 @@
       "@id": "#t0020",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Blank nodes in an array",
-      "purpose": "Empty frame matches all nodes at top-level, and repeats where embedded.",
+      "purpose": "Empty frame matches all nodes at top-level, and repeats where embedded in json-ld-1.0 mode.",
       "input": "frame/0020-in.jsonld",
       "frame": "frame/0020-frame.jsonld",
       "expect": "frame/0020-out.jsonld",
@@ -172,7 +173,7 @@
       "@id": "#t0021",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Blank nodes in @type",
-      "purpose": "Empty frame matches all nodes at top-level, and repeats where embedded (with list content).",
+      "purpose": "Empty frame matches all nodes at top-level, and repeats where embedded (with list content) in json-ld-1.0 mode.",
       "input": "frame/0021-in.jsonld",
       "frame": "frame/0021-frame.jsonld",
       "expect": "frame/0021-out.jsonld",
@@ -251,7 +252,7 @@
     }, {
       "@id": "#t0030",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
-      "name": "@embed",
+      "name": "@embed @always/@never",
       "purpose": "@embed within a frame controls the object embed flag when processing that frame (@always and @never values).",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "frame/0030-in.jsonld",
@@ -396,7 +397,7 @@
       "@id": "#t0046",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Merge graphs if no outer @graph is used",
-      "purpose": "Unless @graph exists at the top level, framing uses merged node objects.",
+      "purpose": "Unless @graph exists at the top level, framing uses merged node objects in json-ld-1.0 mode.",
       "input": "frame/0046-in.jsonld",
       "frame": "frame/0046-frame.jsonld",
       "expect": "frame/0046-out.jsonld",
@@ -423,7 +424,7 @@
       "@id": "#t0049",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Merge one graph and deep preserve another",
-      "purpose": "@graph used within a property value frames embedded values from a named graph.",
+      "purpose": "@graph used within a property value frames embedded values from a named graph in json-ld-1.0 mode.",
       "input": "frame/0049-in.jsonld",
       "frame": "frame/0049-frame.jsonld",
       "expect": "frame/0049-out.jsonld",
@@ -511,18 +512,29 @@
       "@id": "#t0059",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "@embed: @last replaces previous embed values with node reference",
-      "purpose": "Verify that within a matched node, by default only the last reference will be embedded.",
+      "purpose": "Verify that within a matched node, by default only the last reference will be embedded in json-ld-1.0 mode.",
       "input": "frame/0059-in.jsonld",
       "frame": "frame/0059-frame.jsonld",
-      "expect": "frame/0059-out.jsonld"
+      "expect": "frame/0059-out.jsonld",
+      "options": {"spec-version": "json-ld-1.1", "processingMode": "json-ld-1.0"}
     }, {
       "@id": "#t0060",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
-      "name": "@embed: @first only embeds first value with node reference",
+      "name": "@embed: @once only embeds first value with node reference",
       "purpose": "Verify that within a matched node and @embed: @first, by only the first reference will be embedded.",
       "input": "frame/0060-in.jsonld",
       "frame": "frame/0060-frame.jsonld",
-      "expect": "frame/0060-out.jsonld"
+      "expect": "frame/0060-out.jsonld",
+      "options": {"spec-version": "json-ld-1.1", "ordered": true}
+    }, {
+      "@id": "#teo01",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "@embed true/false",
+      "purpose": "@embed within a frame controls the object embed flag when processing that frame (true and false values).",
+      "input": "frame/eo01-in.jsonld",
+      "frame": "frame/eo01-frame.jsonld",
+      "expect": "frame/eo01-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
     }, {
       "@id": "#tg001",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],

--- a/tests/frame/eo01-frame.jsonld
+++ b/tests/frame/eo01-frame.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "ex": "http://www.example.com/#"
+  },
+  "@type": "ex:Thing",
+  "ex:embed": {
+    "@embed": true
+  },
+  "ex:noembed": {
+    "@embed": false
+  }
+}

--- a/tests/frame/eo01-in.jsonld
+++ b/tests/frame/eo01-in.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "ex": "http://www.example.com/#"
+  },
+  "@id": "ex:subject",
+  "@type": "ex:Thing",
+  "ex:embed": {
+    "@id": "ex:embedded",
+    "ex:title": "Embedded"
+  },
+  "ex:noembed": {
+    "@id": "ex:notembedded",
+    "ex:title": "Not Embedded"
+  }
+}

--- a/tests/frame/eo01-out.jsonld
+++ b/tests/frame/eo01-out.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "ex": "http://www.example.com/#"
+  },
+  "@id": "ex:subject",
+  "@type": "ex:Thing",
+  "ex:embed": {
+    "@id": "ex:embedded",
+    "ex:title": "Embedded"
+  },
+  "ex:noembed": {
+    "@id": "ex:notembedded"
+  }
+}

--- a/tests/frame/eo02-frame.jsonld
+++ b/tests/frame/eo02-frame.jsonld
@@ -1,6 +1,7 @@
 {
   "@context": {
-    "ex": "http://www.example.com/#"
+    "@version": 1.1,
+    "ex": "http://www.example.com/#",
   },
   "@type": "ex:Thing",
   "@embed": "@once"

--- a/tests/frame/eo02-in.jsonld
+++ b/tests/frame/eo02-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "ex": "http://www.example.com/#"
+  },
+  "@id": "http://example/outer",
+  "@type": "ex:Thing",
+  "ex:embed1": {"@id": "http://example/embedded", "ex:name": "Embedded"},
+  "ex:embed2": {"@id": "http://example/embedded", "ex:name": "Embedded"}
+}

--- a/tests/frame/eo02-out.jsonld
+++ b/tests/frame/eo02-out.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "ex": "http://www.example.com/#"
+  },
+  "@id": "http://example/outer",
+  "@type": "ex:Thing",
+  "ex:embed1": {"@id": "http://example/embedded", "ex:name": "Embedded"},
+  "ex:embed2": {"@id": "http://example/embedded"}
+}


### PR DESCRIPTION
Some pre-existing tests marked `json-ld-1.0` and new tests added. The `ordered` option is added to these tests to guarantee predictable results.

Fixes #43.