### PR TITLE
added missing normative/informative class in intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@
   </section>
 </section>
 
-<section id='introduction'>
+<section id='introduction' class="informative">
 <h1>Introduction</h1>
 <p>JSON-LD is a lightweight syntax to serialize Linked Data [[LINKED-DATA]] in JSON [[RFC8259]].
   Its design allows existing JSON to be interpreted as Linked Data with minimal changes.
@@ -297,7 +297,7 @@
   they relate to "nest" into a particular tree structure that matches what
   their application expects.</p>
 
-<section>
+<section class="informative">
 <h2>How to Read this Document</h2>
 
 <p>
@@ -349,7 +349,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
   <div data-include="common/typographical-conventions.html"></div>
 </section>
 
-<section>
+<section class="normative">
     <h2>Terminology</h2>
 
     <p>This document uses the following terms as defined in JSON [[RFC8259]]. Refer


### PR DESCRIPTION
Just as in API document: added these classes for the sake of homogeneity. Also, in this document, the introduction was (implicitly) appearing as normative, which is probably not good.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/53.html" title="Last updated on May 24, 2019, 3:04 PM UTC (8e29045)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/53/41bb3e5...8e29045.html" title="Last updated on May 24, 2019, 3:04 PM UTC (8e29045)">Diff</a>