### PR TITLE
Fix lost array with container: set

### DIFF
--- a/index.html
+++ b/index.html
@@ -1670,7 +1670,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
   in any property value within <var>result</var>.</p>
 <p>Recursively, replace all <a>entries</a> in <var>results</var>
   where the key is `@preserve` with the first value of that <a>entry</a>.
-  <span class="note">The value of the entry will be an array with a single value,
+  <span class="note">The value of the entry will be an array with a single value;
     this will effectively replace the map containing `@preserve` with that value.</span></p>
 <p>Set <var>compacted results</var> to the result of using the
   <code class="idlMemberName"><a data-cite="JSON-LD11-API#dom-jsonldprocessor-compact">compact</a></code>

--- a/index.html
+++ b/index.html
@@ -1668,22 +1668,23 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
   remove the <code>@id</code> <a>entry</a> of each <a>node object</a> where the
   <a>entry</a> value is a <a>blank node identifier</a> which appears only once
   in any property value within <var>result</var>.</p>
-<p>Using <var>result</var> from the recursive algorithm, set <var>compacted results</var> to the result of using the
+<p>Recursively, replace all <a>entries</a> in <var>results</var>
+  where the key is `@preserve` with the first value of that <a>entry</a>.
+  <span class="note">The value of the entry will be an array with a single value,
+    this will effectively replace the map containing `@preserve` with that value.</span></p>
+<p>Set <var>compacted results</var> to the result of using the
   <code class="idlMemberName"><a data-cite="JSON-LD11-API#dom-jsonldprocessor-compact">compact</a></code>
   method using <var>results</var>, <a>context</a>, and
   <a data-lt="JsonLdProcessor-frame-options">options</a>.</p>
+<p>Recursively, replace all `@null` values in <var>compacted results</var> with `null`.
+  If, after replacement, an <a>array</a> contains only the value `null` remove that value, leaving
+  an empty array.</p>
 <p>If <span class="changed">the <a>omit graph flag</a> is <code>false</code> and</span>
   <var>compacted results</var> does not have a top-level <code>@graph</code> <a>entry</a>, or its value is
   not an <a>array</a>, modify <var>compacted results</var> to place the non <code>@context</code> <a>properties</a>
   of <var>compacted results</var> into a <a>map</a> contained within the array value of
   <code>@graph</code>. If the <a>omit graph flag</a> is <code>true</code>, a
   top-level <code>@graph</code> <a>entry</a> is used only to contain multiple <a>node objects</a>.</p>
-<p>Recursively, replace all <a>entries</a> in <var>compacted results</var>
-  where the key is <code>@preserve</code> with the value of the <a>entry</a>.
-  If the value of the <a>entry</a> is <code>@null</code>, replace the value with <code>null</code>.
-  <span class="changed">If, after replacement, an array contains a single array value, replace the array with that value.</span>
-  If, after replacement, an array contains only the value <a>null</a> remove the value, leaving
-  an empty <a>array</a>.</p>
 <p>Return <var>compacted results</var>.</p>
 
 </section>

--- a/tests/frame-manifest.jsonld
+++ b/tests/frame-manifest.jsonld
@@ -536,6 +536,15 @@
       "expect": "frame/0061-out.jsonld",
       "options": {"spec-version": "json-ld-1.1"}
     }, {
+      "@id": "#t0062",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "An array with a single value remains an array if container is @set.",
+      "purpose": "Cleaning up @preserve/@null does not violate container: @set.",
+      "input": "frame/0062-in.jsonld",
+      "frame": "frame/0062-frame.jsonld",
+      "expect": "frame/0062-out.jsonld",
+      "options": {"spec-version": "json-ld-1.1"}
+    }, {
       "@id": "#teo01",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "@embed true/false",

--- a/tests/frame-manifest.jsonld
+++ b/tests/frame-manifest.jsonld
@@ -545,6 +545,15 @@
       "expect": "frame/0062-out.jsonld",
       "options": {"spec-version": "json-ld-1.1"}
     }, {
+      "@id": "#t0063",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Using @null in @default.",
+      "purpose": "@null may be used as an @default value and is preserved in output.",
+      "input": "frame/0063-in.jsonld",
+      "frame": "frame/0063-frame.jsonld",
+      "expect": "frame/0063-out.jsonld",
+      "options": {"spec-version": "json-ld-1.1"}
+    }, {
       "@id": "#teo01",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "@embed true/false",

--- a/tests/frame/0062-frame.jsonld
+++ b/tests/frame/0062-frame.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/vocab#",
+    "Production": {
+      "@context": {
+        "part": {
+          "@type": "@id", 
+          "@container": "@set"
+        }
+      }
+    }
+  },
+  "@id": "http://example.org/1"
+}

--- a/tests/frame/0062-in.jsonld
+++ b/tests/frame/0062-in.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/vocab#"
+  },
+  "@id": "http://example.org/1",
+  "@type": "HumanMadeObject",
+  "produced_by": {
+    "@type": "Production",
+    "_label": "Top Production",
+    "part": {
+      "@type": "Production",
+      "_label": "Test Part"
+    }
+  }
+}

--- a/tests/frame/0062-out.jsonld
+++ b/tests/frame/0062-out.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/vocab#",
+    "Production": {
+      "@context": {
+        "part": {
+          "@type": "@id", 
+          "@container": "@set"
+        }
+      }
+    }
+  },
+  "@id": "http://example.org/1",
+  "@type": "HumanMadeObject",
+  "produced_by": {
+    "@type": "Production",
+    "part": [{
+      "@type": "Production",
+      "_label": "Test Part"
+    }],
+    "_label": "Top Production"
+  }
+}

--- a/tests/frame/0063-frame.jsonld
+++ b/tests/frame/0063-frame.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "ex": "http://example.org/vocab#",
+    "ex:p3": {"@container": "@set"}
+  },
+  "@type": "ex:Example",
+  "ex:p1": "non-default",
+  "ex:p2": {"@default": "@null"},
+  "ex:p3": {"@default": ["@null"]}
+}

--- a/tests/frame/0063-in.jsonld
+++ b/tests/frame/0063-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "ex": "http://example.org/vocab#"
+  },
+  "@id": "http://example.org/test/#example1",
+  "@type": "ex:Example",
+  "ex:p1": "non-default"
+}

--- a/tests/frame/0063-out.jsonld
+++ b/tests/frame/0063-out.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "ex": "http://example.org/vocab#",
+    "ex:p3": {"@container": "@set"}
+  },
+  "@id": "http://example.org/test/#example1",
+  "@type": "ex:Example",
+  "ex:p1": "non-default",
+  "ex:p2": null,
+  "ex:p3": []
+}


### PR DESCRIPTION
* Separate `@preserve` from `@null` processing.
* Add tests for `@null` as a default value.

Fixes #64


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/65.html" title="Last updated on Aug 18, 2019, 4:04 PM UTC (72ee9d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/65/0ecbc60...72ee9d2.html" title="Last updated on Aug 18, 2019, 4:04 PM UTC (72ee9d2)">Diff</a>