### PR TITLE
Ignore language case when framing

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -113,8 +113,9 @@
     consists of a string and a non-empty language tag
     as defined by [[BCP47]].
     The <dfn data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</dfn> MUST be well-formed
-    according to <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a> of [[BCP47]],
-    and is normalized to lowercase.</dd>
+    according to <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a> of [[BCP47]].
+    <span class="changed note">Processors MAY normalize <a>language tags</a> to lowercase.</span>
+  </dd>
   <dt><dfn data-cite="LINKED-DATA" data-no-xref="" class="preserve">Linked Data</dfn></dt><dd>
     A set of documents, each containing a representation of a <a>linked data graph</a> or <a>dataset</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-graph" data-lt="linked data graph|graph" class="preserve">RDF graph</dfn></dt><dd>

--- a/index.html
+++ b/index.html
@@ -1747,7 +1747,8 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
     <dt><code>[<a>value object</a>]</code> (<code><dfn>value pattern</dfn></code>)</dt>
     <dd>A <a>value object</a>, used to match a specific value. Within a <a>value object</a>,
       the values for <code>@value</code>, <code>@type</code>, and <code>@language</code>
-      may also be an array of one or more <a>string</a> values.</dd>
+      may also be an array of one or more <a>string</a> values,
+      <span class="changed">values of `@language` are compared without regard to case.</span>.</dd>
   </dl>
 
 <p>The frame matching algorithm takes the <a>framing state</a> (<var>state</var>),
@@ -1827,8 +1828,10 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
     Value matches pattern using the following algorithm:</p>
 
   <ol>
-    <li>Let <var>v1</var>, <var>t1</var>, and <var>l1</var> be the values of <code>@value</code>, <code>@type</code>, and <code>@language</code> in <var>value</var>, or <strong>null</strong> if none exists.</li>
-    <li>Let <var>v2</var>, <var>t2</var>, and <var>l2</var> be the values of <code>@value</code>, <code>@type</code>, and <code>@language</code> in <var>value pattern</var>, or <strong>null</strong> if none exists.</li>
+    <li>Let <var>v1</var>, <var>t1</var>, and <var>l1</var> be the values of <code>@value</code>, <code>@type</code>, and <code>@language</code> in <var>value</var>, or <strong>null</strong> if none exists,
+      <span class="changed">where values of `@language` are normalized to lower case.</span>.</li>
+    <li>Let <var>v2</var>, <var>t2</var>, and <var>l2</var> be the values of <code>@value</code>, <code>@type</code>, and <code>@language</code> in <var>value pattern</var>, or <strong>null</strong> if none exists,
+      <span class="changed">where string values of `@language` are normalized to lower case.</span>.</li>
     <li><var>Value</var> matches <var>pattern</var> when <var>pattern</var> is <code><a>wildcard</a></code>, or:
       <ol>
         <li><var>v1</var> is in <var>v2</var>, or <var>v1</var> is not <strong>null</strong> and <var>v2</var> is <code><a>wildcard</a></code>, and</li>

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,6 +28,7 @@ JSON-LD Object comparison compares JSON objects, arrays, and values recursively 
 * JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.
 * JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is `@list`). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of `@list`, the order of these items is significant.
 * JSON values are compared using strict equality.
+* Values of `@language`, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.
 
 Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have `@container: @list` and the comparison algorithm will not consider ordering significant.
 

--- a/tests/frame-manifest.html
+++ b/tests/frame-manifest.html
@@ -49,9 +49,10 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 <p>JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.</p>
 
 <ul>
-<li>JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.</li>
+<li>JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.</li>
 <li>JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is <code>@list</code>). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of <code>@list</code>, the order of these items is significant.</li>
 <li>JSON values are compared using strict equality.</li>
+<li>Values of <code>@language</code>, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.</li>
 </ul>
 
 <p>Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have <code>@container: @list</code> and the comparison algorithm will not consider ordering significant.</p>

--- a/tests/manifest.html
+++ b/tests/manifest.html
@@ -49,9 +49,10 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 <p>JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.</p>
 
 <ul>
-<li>JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.</li>
+<li>JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.</li>
 <li>JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is <code>@list</code>). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of <code>@list</code>, the order of these items is significant.</li>
 <li>JSON values are compared using strict equality.</li>
+<li>Values of <code>@language</code>, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.</li>
 </ul>
 
 <p>Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have <code>@container: @list</code> and the comparison algorithm will not consider ordering significant.</p>

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -50,9 +50,10 @@
 
       JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.
 
-      * JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.
+      * JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.
       * JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is `@list`). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of `@list`, the order of these items is significant.
       * JSON values are compared using strict equality.
+      * Values of `@language`, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.
 
       Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have `@container: @list` and the comparison algorithm will not consider ordering significant.
 


### PR DESCRIPTION
For For w3c/json-ld-api#167.

Note, tests already exist with mismatched language tags.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/75.html" title="Last updated on Oct 14, 2019, 9:26 PM UTC (44f9bc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/75/18bce59...44f9bc0.html" title="Last updated on Oct 14, 2019, 9:26 PM UTC (44f9bc0)">Diff</a>