### PR TITLE
Lazy-Eval processingMode.

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -320,13 +320,16 @@
     when prepended to the suffix of the <a>compact IRI</a>,
     results in an <a>absolute IRI</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-processing-mode">processing mode</dfn></dt><dd>
-    The processing mode defines how a <a>JSON-LD document</a> is processed.
-    By default, all documents are assumed to be conformant with <a data-cite="JSON-LD10" data-no-xref="">JSON-LD 1.0</a> [[JSON-LD10]].
+    The <a>processing mode</a> defines how a <a>JSON-LD document</a> is processed.
+    By default, all documents are assumed to be conformant with this specification.
     By defining a different version using the <code>@version</code> <a>entry</a> in a <a>context</a>,
-    or via explicit API option,
-    other processing modes can be accessed.
+    publishers can ensure that processors conformant with <a data-cite="JSON-LD10" data-no-xref="">JSON-LD 1.0</a> [[JSON-LD10]]
+    will not accidently process JSON-LD 1.1 documents, possibly creating a different output.
+    The API provides an option for setting the <a>processing mode</a> to `json-ld-1.0`,
+    which will prevent JSON-LD 1.1 features from being activated,
+    or error if <code>@version</code> <a>entry</a> in a <a>context</a> is explicitly set to `1.1`.
     This specification extends <a data-cite="JSON-LD10" data-no-xref="">JSON-LD 1.0</a>
-    via the <code>json-ld-1.1</code> <a>processing mode</a>.</dd>
+    via the `json-ld-1.1` <a>processing mode</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-set-object">set object</dfn></dt><dd>
     A <a>set object</a> is a <a>map</a> that has an <code>@set</code> <a>entry</a>.
     It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>

--- a/index.html
+++ b/index.html
@@ -69,10 +69,16 @@
       ],
 
       formerEditors:  [
-          { name: "Manu Sporny", url: "http://manu.sporny.org/",
-            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/" },
-          { name: "Markus Lanthaler", url: "http://www.markus-lanthaler.com/",
-            company: "Graz University of Technology", companyURL: "http://www.tugraz.at/" }
+        { name: "Manu Sporny",
+          url: "http://manu.sporny.org/",
+          company: "Digital Bazaar",
+          companyURL: "https://digitalbazaar.com/",
+          note:       "v1.0" },
+        { name: "Markus Lanthaler",
+          url: "http://www.markus-lanthaler.com/",
+          company: "Graz University of Technology",
+          companyURL: "http://www.tugraz.at/",
+          note:       "v1.0" }
       ],
 
       // authors, add as many as you like.
@@ -408,6 +414,16 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
 
 <section class="informative">
 <h2>Features</h2>
+
+  <p class="changed">JSON-LD 1.1 introduces new features that are
+    compatible with [[[JSON-LD10]]] [[JSON-LD10]],
+    but if processed by a JSON-LD 1.0 processor may produce different results.
+    Processors default to `json-ld-1.1`, unless the
+    <a data-cite="JSON-LD11-API#dom-jsonldoptions-processingMode">processingMode</a> API option
+    is explicitly set to `json-ld-1.0`.
+    Publishers are encouraged to use the <code>@version</code> <a>map entry</a> within a <a>context</a>
+    set to `1.1` to ensure that JSON-LD 1.0 processors will not misinterpret JSON-LD 1.1 features.</p>
+
   <section class="informative">
     <h3>Framing</h3>
     <p><dfn>Framing</dfn> is used to shape the data in a <a>JSON-LD document</a>,
@@ -518,7 +534,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
       </pre>
     </aside>
 
-    <p>If <a>processing mode</a> is <code>json-ld-1.1</code>, or the <a>omit graph flag</a> is <code>true</code>,
+    <p>If <a>processing mode</a> is not <code>json-ld-1.0</code>, or the <a>omit graph flag</a> is <code>true</code>,
       the top-level <code>@graph</code> <a>entry</a> may be omitted.</p>
 
     <pre class="example result" data-transform="updateExample"
@@ -1363,6 +1379,18 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
     than conversion between <a data-lt="relative IRI">relative</a> and
     <a>absolute IRIs</a>.</p>
 
+  <p class="changed">Unless specified using
+    <a data-cite="JSON-LD11-API#dom-jsonldoptions-processingMode">processingMode</a> API option,
+    the <a>processing mode</a> is set using the <code>@version</code> <a>entry</a>
+    in a local <a>context</a> and
+    affects the behavior of algorithms including <a data-cite="JSON-LD11-API#dfn-expanded">expansion</a> and <a data-cite="JSON-LD11-API#dfn-compacted">compaction</a>.
+    Once set, it is an error to attempt to change to a different processing mode,
+    and processors MUST generate,
+    a <a data-cite="JSON-LD11-API#dom-jsonlderrorcode-processing-mode-conflict">processing mode conflict</a>
+    error and abort further processing.
+    If unspecified, processors MUST set <a>processing mode</a> to `json-ld-1.1`
+    on the first attempt to use a JSON-LD 1.1 feature.</p>
+
   <p>The algorithms in this specification are generally written with more concern for clarity
     than efficiency. Thus, <a>JSON-LD Processors</a> MAY
     implement the algorithms given in this specification in any way desired,
@@ -1694,7 +1722,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
   </li>
 </ol>
 
-<p class="changed">If the <a>processing mode</a> is <code>json-ld-1.1</code>,
+<p class="changed">If the <a>processing mode</a> is not <code>json-ld-1.0</code>,
   remove the <code>@id</code> <a>entry</a> of each <a>node object</a> where the
   <a>entry</a> value is a <a>blank node identifier</a> which appears only once
   in any property value within <var>result</var>.</p>
@@ -2040,7 +2068,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
       <dt class="changed"><dfn data-dfn-for="JsonLdOptions">omitGraph</dfn></dt>
       <dd class="changed">Sets the value <a>omit graph flag</a> used in the
         <a href="#framing-algorithm">Framing Algorithm</a>. If not set explicitly,
-        it is set to <code>false</code> if <a>processing mode</a> if <code>json-ld-1.0</code>, <code>true</code> otherwise.</dd>
+        it is set to <code>false</code> if <a>processing mode</a> is <code>json-ld-1.0</code>, <code>true</code> otherwise.</dd>
       <dt><dfn data-dfn-for="JsonLdOptions">requireAll</dfn></dt>
       <dd>Sets the value <a>require all flag</a> used in the
         <a href="#framing-algorithm">Framing Algorithm</a>.</dd>
@@ -2231,7 +2259,7 @@ becomes a W3C Recommendation.</p>
       object.</li>
     <li>Frames can use one or more values for <code>@id</code> to allow for matching
       specific objects in a frame.</li>
-    <li>If <a>processing mode</a> is <code>json-ld-1.1</code>,
+    <li>If <a>processing mode</a> is not <code>json-ld-1.0</code>,
       <code>@id</code> <a>entries</a> with <a>blank node identifiers</a>
       used only for that <code>@id</code> are removed.</li>
     <li>The JSON syntax has been abstracted into an <a>internal representation</a>
@@ -2267,6 +2295,10 @@ becomes a W3C Recommendation.</p>
       <code>@id</code> and <code>@type</code>.</li>
     <li>Removed <code>@first</code> and <code>@last</code> values for the
       <a>object embed flag</a> in favor of <code>@once</code>.</li>
+    <li>The <a>processing mode</a> is now implicitly `json-ld-1.1`, unless set
+      explicitly to `json-ld-1.0`. Processing mode is wired to `json-ld-1.1`
+      when the first JSON-LD 1.1 specific feature is encountered, and it is
+      not set explicilty.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -1387,9 +1387,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
     Once set, it is an error to attempt to change to a different processing mode,
     and processors MUST generate,
     a <a data-cite="JSON-LD11-API#dom-jsonlderrorcode-processing-mode-conflict">processing mode conflict</a>
-    error and abort further processing.
-    If unspecified, processors MUST set <a>processing mode</a> to `json-ld-1.1`
-    on the first attempt to use a JSON-LD 1.1 feature.</p>
+    error and abort further processing.</p>
 
   <p>The algorithms in this specification are generally written with more concern for clarity
     than efficiency. Thus, <a>JSON-LD Processors</a> MAY
@@ -2296,9 +2294,7 @@ becomes a W3C Recommendation.</p>
     <li>Removed <code>@first</code> and <code>@last</code> values for the
       <a>object embed flag</a> in favor of <code>@once</code>.</li>
     <li>The <a>processing mode</a> is now implicitly `json-ld-1.1`, unless set
-      explicitly to `json-ld-1.0`. Processing mode is wired to `json-ld-1.1`
-      when the first JSON-LD 1.1 specific feature is encountered, and it is
-      not set explicilty.</li>
+      explicitly to `json-ld-1.0`.</li>
   </ul>
 </section>
 

--- a/tests/frame-manifest.html
+++ b/tests/frame-manifest.html
@@ -123,6 +123,13 @@ Test t0001 Library framing example
 <dd>
 <a href='frame/0001-out.jsonld'>frame/0001-out.jsonld</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='t0002'>
@@ -147,6 +154,13 @@ Test t0002 reframe w/extra CURIE value.
 <dt>expect</dt>
 <dd>
 <a href='frame/0002-out.jsonld'>frame/0002-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
 </dd>
 </dl>
 </dd>
@@ -173,6 +187,13 @@ Test t0003 reframe (null)
 <dd>
 <a href='frame/0003-out.jsonld'>frame/0003-out.jsonld</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='t0004'>
@@ -197,6 +218,13 @@ Test t0004 reframe (type)
 <dt>expect</dt>
 <dd>
 <a href='frame/0004-out.jsonld'>frame/0004-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
 </dd>
 </dl>
 </dd>
@@ -223,6 +251,13 @@ Test t0005 reframe (explicit)
 <dd>
 <a href='frame/0005-out.jsonld'>frame/0005-out.jsonld</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='t0006'>
@@ -247,6 +282,13 @@ Test t0006 reframe (non-explicit)
 <dt>expect</dt>
 <dd>
 <a href='frame/0006-out.jsonld'>frame/0006-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
 </dd>
 </dl>
 </dd>
@@ -273,6 +315,13 @@ Test t0007 input has multiple types
 <dd>
 <a href='frame/0007-out.jsonld'>frame/0007-out.jsonld</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='t0008'>
@@ -298,6 +347,13 @@ Test t0008 array framing cases
 <dd>
 <a href='frame/0008-out.jsonld'>frame/0008-out.jsonld</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='t0009'>
@@ -322,6 +378,13 @@ Test t0009 default value
 <dt>expect</dt>
 <dd>
 <a href='frame/0009-out.jsonld'>frame/0009-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
 </dd>
 </dl>
 </dd>
@@ -379,6 +442,13 @@ Test t0011 @embed true/false
 <dt>expect</dt>
 <dd>
 <a href='frame/0011-out.jsonld'>frame/0011-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
 </dd>
 </dl>
 </dd>
@@ -505,6 +575,13 @@ Test t0016 Use @type in ducktype filter
 <dd>
 <a href='frame/0016-out.jsonld'>frame/0016-out.jsonld</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='t0017'>
@@ -530,6 +607,13 @@ Test t0017 Non-flat input
 <dd>
 <a href='frame/0017-out.jsonld'>frame/0017-out.jsonld</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='t0018'>
@@ -554,6 +638,13 @@ Test t0018 no frame @context but @graph output
 <dt>expect</dt>
 <dd>
 <a href='frame/0018-out.jsonld'>frame/0018-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
 </dd>
 </dl>
 </dd>
@@ -672,6 +763,13 @@ Test t0022 Match on @id
 <dt>expect</dt>
 <dd>
 <a href='frame/0022-out.jsonld'>frame/0022-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
 </dd>
 </dl>
 </dd>
@@ -1849,6 +1947,15 @@ Test t0059 @embed: @last replaces previous embed values with node reference
 <dd>
 <a href='frame/0059-out.jsonld'>frame/0059-out.jsonld</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='t0060'>
@@ -1873,6 +1980,15 @@ Test t0060 @embed: @once only embeds first value with node reference
 <dt>expect</dt>
 <dd>
 <a href='frame/0060-out.jsonld'>frame/0060-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+<dt>ordered</dt>
+<dd>true</dd>
+</dl>
 </dd>
 </dl>
 </dd>
@@ -1899,6 +2015,13 @@ Test t0061 Matching embedded nodes with @default
 <dd>
 <a href='frame/0061-out.jsonld'>frame/0061-out.jsonld</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='t0062'>
@@ -1924,6 +2047,13 @@ Test t0062 An array with a single value remains an array if container is @set.
 <dd>
 <a href='frame/0062-out.jsonld'>frame/0062-out.jsonld</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='t0063'>
@@ -1948,6 +2078,13 @@ Test t0063 Using @null in @default.
 <dt>expect</dt>
 <dd>
 <a href='frame/0063-out.jsonld'>frame/0063-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
 </dd>
 </dl>
 </dd>

--- a/tests/frame-manifest.html
+++ b/tests/frame-manifest.html
@@ -1701,8 +1701,6 @@ Test t0051 Compacting values of @preserve
 <dl class='options'>
 <dt>specVersion</dt>
 <dd>json-ld-1.1</dd>
-<dt>processingMode</dt>
-<dd>json-ld-1.1</dd>
 </dl>
 </dd>
 </dl>
@@ -2115,8 +2113,6 @@ Test teo01 @embed true/false
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld-1.1</dd>
-<dt>processingMode</dt>
 <dd>json-ld-1.1</dd>
 </dl>
 </dd>
@@ -2566,8 +2562,6 @@ Test tp020 Blank nodes in an array (prune bnodes)
 <dt>Options</dt>
 <dd>
 <dl class='options'>
-<dt>processingMode</dt>
-<dd>json-ld-1.1</dd>
 <dt>specVersion</dt>
 <dd>json-ld-1.1</dd>
 </dl>
@@ -2600,8 +2594,6 @@ Test tp021 Blank nodes in @type (prune bnodes)
 <dt>Options</dt>
 <dd>
 <dl class='options'>
-<dt>processingMode</dt>
-<dd>json-ld-1.1</dd>
 <dt>specVersion</dt>
 <dd>json-ld-1.1</dd>
 </dl>
@@ -2634,8 +2626,6 @@ Test tp046 Merge graphs if no outer @graph is used (prune bnodes)
 <dt>Options</dt>
 <dd>
 <dl class='options'>
-<dt>processingMode</dt>
-<dd>json-ld-1.1</dd>
 <dt>specVersion</dt>
 <dd>json-ld-1.1</dd>
 </dl>
@@ -2668,8 +2658,6 @@ Test tp049 Merge one graph and deep preserve another (prune bnodes)
 <dt>Options</dt>
 <dd>
 <dl class='options'>
-<dt>processingMode</dt>
-<dd>json-ld-1.1</dd>
 <dt>specVersion</dt>
 <dd>json-ld-1.1</dd>
 </dl>
@@ -2702,8 +2690,6 @@ Test tp050 Prune blank nodes with alias of @id
 <dt>Options</dt>
 <dd>
 <dl class='options'>
-<dt>processingMode</dt>
-<dd>json-ld-1.1</dd>
 <dt>specVersion</dt>
 <dd>json-ld-1.1</dd>
 </dl>

--- a/tests/frame-manifest.jsonld
+++ b/tests/frame-manifest.jsonld
@@ -11,6 +11,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Library framing example",
       "purpose": "Basic example used in playgrond and spec examples.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0001-in.jsonld",
       "frame": "frame/0001-frame.jsonld",
       "expect": "frame/0001-out.jsonld"
@@ -19,6 +20,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "reframe w/extra CURIE value.",
       "purpose": "Append extra values to output.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0002-in.jsonld",
       "frame": "frame/0002-frame.jsonld",
       "expect": "frame/0002-out.jsonld"
@@ -27,6 +29,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "reframe (null)",
       "purpose": "Do not match without a matching @type",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0003-in.jsonld",
       "frame": "frame/0003-frame.jsonld",
       "expect": "frame/0003-out.jsonld"
@@ -35,6 +38,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "reframe (type)",
       "purpose": "Multiple matches on @type.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0004-in.jsonld",
       "frame": "frame/0004-frame.jsonld",
       "expect": "frame/0004-out.jsonld"
@@ -43,6 +47,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "reframe (explicit)",
       "purpose": "If property is not in frame, and explicit is true, do not add any values for property to output.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0005-in.jsonld",
       "frame": "frame/0005-frame.jsonld",
       "expect": "frame/0005-out.jsonld"
@@ -51,6 +56,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "reframe (non-explicit)",
       "purpose": "Unless the explicit is false, processors append extra values to output.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0006-in.jsonld",
       "frame": "frame/0006-frame.jsonld",
       "expect": "frame/0006-out.jsonld"
@@ -59,6 +65,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "input has multiple types",
       "purpose": "If property is a keyword, processors add property and objects to output.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0007-in.jsonld",
       "frame": "frame/0007-frame.jsonld",
       "expect": "frame/0007-out.jsonld"
@@ -67,6 +74,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "array framing cases",
       "purpose": "Various cases showing array output for @container: @set, and non-embedding of node values if @embed: false.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0008-in.jsonld",
       "frame": "frame/0008-frame.jsonld",
       "expect": "frame/0008-out.jsonld"
@@ -75,6 +83,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "default value",
       "purpose": "Processors MUST skip property and property frame if property frame contains @omitDefault with a value of true. Processors MUST add property to output with a new dictionary having a property @preserve and a value that is a copy of the value of @default in frame if it exists, or the string @null otherwise.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0009-in.jsonld",
       "frame": "frame/0009-frame.jsonld",
       "expect": "frame/0009-out.jsonld"
@@ -95,7 +104,7 @@
       "input": "frame/0011-in.jsonld",
       "frame": "frame/0011-frame.jsonld",
       "expect": "frame/0011-out.jsonld",
-      "options": {"spec-version": "json-ld-1.1", "processingMode": "json-ld-1.0"}
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#t0012",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -133,6 +142,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Use @type in ducktype filter",
       "purpose": "Match if node has a @type property and frame has a @type property containing only an empty dictionary.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0016-in.jsonld",
       "frame": "frame/0016-frame.jsonld",
       "expect": "frame/0016-out.jsonld"
@@ -141,6 +151,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Non-flat input",
       "purpose": "Framing flattens expanded input, allowing for deeply embedded input to be re-framed.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0017-in.jsonld",
       "frame": "frame/0017-frame.jsonld",
       "expect": "frame/0017-out.jsonld"
@@ -149,6 +160,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "no frame @context but @graph output",
       "purpose": "Set framing context to the value of @context from frame, if it exists, or to a new empty context, otherwise.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0018-in.jsonld",
       "frame": "frame/0018-frame.jsonld",
       "expect": "frame/0018-out.jsonld"
@@ -183,6 +195,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Match on @id",
       "purpose": "Match if node and frame both have the same @id property.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "frame/0022-in.jsonld",
       "frame": "frame/0022-frame.jsonld",
       "expect": "frame/0022-out.jsonld"
@@ -516,7 +529,7 @@
       "input": "frame/0059-in.jsonld",
       "frame": "frame/0059-frame.jsonld",
       "expect": "frame/0059-out.jsonld",
-      "options": {"spec-version": "json-ld-1.1", "processingMode": "json-ld-1.0"}
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.0"}
     }, {
       "@id": "#t0060",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -525,7 +538,7 @@
       "input": "frame/0060-in.jsonld",
       "frame": "frame/0060-frame.jsonld",
       "expect": "frame/0060-out.jsonld",
-      "options": {"spec-version": "json-ld-1.1", "ordered": true}
+      "option": {"specVersion": "json-ld-1.1", "ordered": true}
     }, {
       "@id": "#t0061",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -534,7 +547,7 @@
       "input": "frame/0061-in.jsonld",
       "frame": "frame/0061-frame.jsonld",
       "expect": "frame/0061-out.jsonld",
-      "options": {"spec-version": "json-ld-1.1"}
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#t0062",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -543,7 +556,7 @@
       "input": "frame/0062-in.jsonld",
       "frame": "frame/0062-frame.jsonld",
       "expect": "frame/0062-out.jsonld",
-      "options": {"spec-version": "json-ld-1.1"}
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#t0063",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -552,7 +565,7 @@
       "input": "frame/0063-in.jsonld",
       "frame": "frame/0063-frame.jsonld",
       "expect": "frame/0063-out.jsonld",
-      "options": {"spec-version": "json-ld-1.1"}
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#teo01",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],

--- a/tests/frame-manifest.jsonld
+++ b/tests/frame-manifest.jsonld
@@ -455,7 +455,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Compacting values of @preserve",
       "purpose": "When compacting the value of a property using @preserve, use the term definition for term to properly compact the value of @preserve.",
-      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame/0051-in.jsonld",
       "frame": "frame/0051-frame.jsonld",
       "expect": "frame/0051-out.jsonld"
@@ -574,7 +574,7 @@
       "input": "frame/eo01-in.jsonld",
       "frame": "frame/eo01-frame.jsonld",
       "expect": "frame/eo01-out.jsonld",
-      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tg001",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -700,7 +700,7 @@
       "input": "frame/0020-in.jsonld",
       "frame": "frame/0020-frame.jsonld",
       "expect": "frame/p020-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp021",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -709,7 +709,7 @@
       "input": "frame/0021-in.jsonld",
       "frame": "frame/0021-frame.jsonld",
       "expect": "frame/p021-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp046",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -718,7 +718,7 @@
       "input": "frame/0046-in.jsonld",
       "frame": "frame/0046-frame.jsonld",
       "expect": "frame/p046-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp049",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -727,7 +727,7 @@
       "input": "frame/0049-in.jsonld",
       "frame": "frame/0049-frame.jsonld",
       "expect": "frame/p049-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp050",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -736,7 +736,7 @@
       "input": "frame/p050-in.jsonld",
       "frame": "frame/p050-frame.jsonld",
       "expect": "frame/p050-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tra01",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],

--- a/tests/frame/0011-out.jsonld
+++ b/tests/frame/0011-out.jsonld
@@ -2,15 +2,13 @@
   "@context": {
     "ex": "http://www.example.com/#"
   },
-  "@graph": [{
-    "@id": "ex:subject",
-    "@type": "ex:Thing",
-    "ex:embed": {
-      "@id": "ex:embedded",
-      "ex:title": "Embedded"
-    },
-    "ex:noembed": {
-      "@id": "ex:notembedded"
-    }
-  }]
+  "@id": "ex:subject",
+  "@type": "ex:Thing",
+  "ex:embed": {
+    "@id": "ex:embedded",
+    "ex:title": "Embedded"
+  },
+  "ex:noembed": {
+    "@id": "ex:notembedded"
+  }
 }

--- a/tests/frame/0023-out.jsonld
+++ b/tests/frame/0023-out.jsonld
@@ -1,8 +1,6 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "ex:p": null,
-    "ex:q": "bar"
-  }]
+  "@id": "ex:Sub1",
+  "ex:p": null,
+  "ex:q": "bar"
 }

--- a/tests/frame/0026-out.jsonld
+++ b/tests/frame/0026-out.jsonld
@@ -1,7 +1,5 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "@type": "ex:Type1"
-  }]
+  "@id": "ex:Sub1",
+  "@type": "ex:Type1"
 }

--- a/tests/frame/0027-out.jsonld
+++ b/tests/frame/0027-out.jsonld
@@ -2,13 +2,11 @@
   "@context": {
     "ex": "http://example.org/"
   },
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "@type": "ex:Type1",
-    "ex:prop1": "Property 1",
-    "ex:prop2": {
-      "@id": "ex:Obj1"
-    },
-    "ex:null": null
-  }]
+  "@id": "ex:Sub1",
+  "@type": "ex:Type1",
+  "ex:prop1": "Property 1",
+  "ex:prop2": {
+    "@id": "ex:Obj1"
+  },
+  "ex:null": null
 }

--- a/tests/frame/0028-out.jsonld
+++ b/tests/frame/0028-out.jsonld
@@ -1,16 +1,14 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "@type": "ex:Type1",
-    "@reverse": {
+  "@id": "ex:Sub1",
+  "@type": "ex:Type1",
+  "@reverse": {
+    "ex:includes": {
+      "@id": "ex:Sub2",
+      "@type": "ex:Type2",
       "ex:includes": {
-        "@id": "ex:Sub2",
-        "@type": "ex:Type2",
-        "ex:includes": {
-          "@id": "ex:Sub1"
-        }
+        "@id": "ex:Sub1"
       }
     }
-  }]
+  }
 }

--- a/tests/frame/0029-out.jsonld
+++ b/tests/frame/0029-out.jsonld
@@ -3,13 +3,11 @@
     "ex": "http://example.org/",
     "excludes": {"@reverse": "ex:includes"}
   },
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "@type": "ex:Type1",
-    "excludes": {
-      "@id": "ex:Sub2",
-      "@type": "ex:Type2",
-      "ex:includes": {"@id": "ex:Sub1"}
-    }
-  }]
+  "@id": "ex:Sub1",
+  "@type": "ex:Type1",
+  "excludes": {
+    "@id": "ex:Sub2",
+    "@type": "ex:Type2",
+    "ex:includes": {"@id": "ex:Sub1"}
+  }
 }

--- a/tests/frame/0030-out.jsonld
+++ b/tests/frame/0030-out.jsonld
@@ -2,15 +2,13 @@
   "@context": {
     "ex": "http://www.example.com/#"
   },
-  "@graph": [{
-    "@id": "ex:subject",
-    "@type": "ex:Thing",
-    "ex:embed": {
-      "@id": "ex:embedded",
-      "ex:title": "Embedded"
-    },
-    "ex:noembed": {
-      "@id": "ex:notembedded"
-    }
-  }]
+  "@id": "ex:subject",
+  "@type": "ex:Thing",
+  "ex:embed": {
+    "@id": "ex:embedded",
+    "ex:title": "Embedded"
+  },
+  "ex:noembed": {
+    "@id": "ex:notembedded"
+  }
 }

--- a/tests/frame/0031-out.jsonld
+++ b/tests/frame/0031-out.jsonld
@@ -1,7 +1,5 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub2",
-    "ex:p": "Bar"
-  }]
+  "@id": "ex:Sub2",
+  "ex:p": "Bar"
 }

--- a/tests/frame/0032-out.jsonld
+++ b/tests/frame/0032-out.jsonld
@@ -1,7 +1,5 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "@type": "ex:Type1"
-  }]
+  "@id": "ex:Sub1",
+  "@type": "ex:Type1"
 }

--- a/tests/frame/0034-out.jsonld
+++ b/tests/frame/0034-out.jsonld
@@ -1,8 +1,6 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "ex:p": null,
-    "ex:q": "bar"
-  }]
+  "@id": "ex:Sub1",
+  "ex:p": null,
+  "ex:q": "bar"
 }

--- a/tests/frame/0035-out.jsonld
+++ b/tests/frame/0035-out.jsonld
@@ -1,12 +1,10 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "@type": "ex:Type1",
-    "ex:p": {
-      "@id": "ex:Sub2",
-      "@type": "ex:Type2",
-      "ex:q": "foo"
-    }
-  }]
+  "@id": "ex:Sub1",
+  "@type": "ex:Type1",
+  "ex:p": {
+    "@id": "ex:Sub2",
+    "@type": "ex:Type2",
+    "ex:q": "foo"
+  }
 }

--- a/tests/frame/0036-out.jsonld
+++ b/tests/frame/0036-out.jsonld
@@ -1,9 +1,7 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "ex:p": "P",
-    "ex:q": {"@value": "Q", "@type": "ex:q"},
-    "ex:r": {"@value": "R", "@language": "r"}
-  }]
+  "@id": "ex:Sub1",
+  "ex:p": "P",
+  "ex:q": {"@value": "Q", "@type": "ex:q"},
+  "ex:r": {"@value": "R", "@language": "r"}
 }

--- a/tests/frame/0037-out.jsonld
+++ b/tests/frame/0037-out.jsonld
@@ -1,9 +1,7 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "ex:p": "P",
-    "ex:q": {"@value": "Q", "@type": "ex:q"},
-    "ex:r": {"@value": "R", "@language": "r"}
-  }]
+  "@id": "ex:Sub1",
+  "ex:p": "P",
+  "ex:q": {"@value": "Q", "@type": "ex:q"},
+  "ex:r": {"@value": "R", "@language": "r"}
 }

--- a/tests/frame/0038-out.jsonld
+++ b/tests/frame/0038-out.jsonld
@@ -1,7 +1,5 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "ex:q": {"@value": "Q", "@type": "ex:q"}
-  }]
+  "@id": "ex:Sub1",
+  "ex:q": {"@value": "Q", "@type": "ex:q"}
 }

--- a/tests/frame/0039-out.jsonld
+++ b/tests/frame/0039-out.jsonld
@@ -1,7 +1,5 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "ex:r": {"@value": "R", "@language": "r"}
-  }]
+  "@id": "ex:Sub1",
+  "ex:r": {"@value": "R", "@language": "r"}
 }

--- a/tests/frame/0040-out.jsonld
+++ b/tests/frame/0040-out.jsonld
@@ -1,9 +1,7 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "ex:p": "P",
-    "ex:q": {"@value": "Q", "@type": "ex:q"},
-    "ex:r": {"@value": "R", "@language": "r"}
-  }]
+  "@id": "ex:Sub1",
+  "ex:p": "P",
+  "ex:q": {"@value": "Q", "@type": "ex:q"},
+  "ex:r": {"@value": "R", "@language": "r"}
 }

--- a/tests/frame/0041-out.jsonld
+++ b/tests/frame/0041-out.jsonld
@@ -1,9 +1,7 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "ex:p": "P",
-    "ex:q": {"@value": "Q", "@type": "ex:q"},
-    "ex:r": {"@value": "R", "@language": "r"}
-  }]
+  "@id": "ex:Sub1",
+  "ex:p": "P",
+  "ex:q": {"@value": "Q", "@type": "ex:q"},
+  "ex:r": {"@value": "R", "@language": "r"}
 }

--- a/tests/frame/0042-out.jsonld
+++ b/tests/frame/0042-out.jsonld
@@ -1,9 +1,7 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "ex:p": "P",
-    "ex:q": {"@value": "Q", "@type": "ex:q"},
-    "ex:r": {"@value": "R", "@language": "r"}
-  }]
+  "@id": "ex:Sub1",
+  "ex:p": "P",
+  "ex:q": {"@value": "Q", "@type": "ex:q"},
+  "ex:r": {"@value": "R", "@language": "r"}
 }

--- a/tests/frame/0043-out.jsonld
+++ b/tests/frame/0043-out.jsonld
@@ -1,7 +1,5 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "ex:q": {"@value": "Q", "@type": "ex:q"}
-  }]
+  "@id": "ex:Sub1",
+  "ex:q": {"@value": "Q", "@type": "ex:q"}
 }

--- a/tests/frame/0044-out.jsonld
+++ b/tests/frame/0044-out.jsonld
@@ -1,7 +1,5 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "ex:r": {"@value": "R", "@language": "r"}
-  }]
+  "@id": "ex:Sub1",
+  "ex:r": {"@value": "R", "@language": "r"}
 }

--- a/tests/frame/0045-out.jsonld
+++ b/tests/frame/0045-out.jsonld
@@ -1,9 +1,7 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "ex:p": "P",
-    "ex:q": {"@value": "Q", "@type": "ex:q"},
-    "ex:r": {"@value": "R", "@language": "r"}
-  }]
+  "@id": "ex:Sub1",
+  "ex:p": "P",
+  "ex:q": {"@value": "Q", "@type": "ex:q"},
+  "ex:r": {"@value": "R", "@language": "r"}
 }

--- a/tests/frame/0047-out.jsonld
+++ b/tests/frame/0047-out.jsonld
@@ -1,14 +1,12 @@
 {
   "@context": {"@vocab": "urn:"},
-  "@graph": [{
-    "@id": "urn:id-1",
-    "@type": "Class",
-    "preserve": {
-      "@id": "urn:gr-1",
-      "@graph": {
-        "@id": "urn:id-2",
-        "term": "data"
-      }
+  "@id": "urn:id-1",
+  "@type": "Class",
+  "preserve": {
+    "@id": "urn:gr-1",
+    "@graph": {
+      "@id": "urn:id-2",
+      "term": "data"
     }
-  }]
+  }
 }

--- a/tests/frame/0048-out.jsonld
+++ b/tests/frame/0048-out.jsonld
@@ -1,18 +1,16 @@
 {
   "@context": {"@vocab": "urn:"},
-  "@graph": [{
-    "@id": "urn:id-1",
-    "@type": "Class",
-    "merge": {
-      "@id": "urn:id-2",
-      "term": "foo"
-    },
-    "preserve": {
-      "@id": "urn:graph-1",
-      "@graph": {
-        "@id": "urn:id-3",
-        "term": "bar"
-      }
+  "@id": "urn:id-1",
+  "@type": "Class",
+  "merge": {
+    "@id": "urn:id-2",
+    "term": "foo"
+  },
+  "preserve": {
+    "@id": "urn:graph-1",
+    "@graph": {
+      "@id": "urn:id-3",
+      "term": "bar"
     }
-  }]
+  }
 }

--- a/tests/frame/0050-out.jsonld
+++ b/tests/frame/0050-out.jsonld
@@ -1,25 +1,21 @@
 {
   "@context": {"@vocab": "http://example.org/"},
-  "@graph": [
-    {
-      "@id": "http://example.org/library",
-      "@type": "Library",
-      "name": "Library",
+  "@id": "http://example.org/library",
+  "@type": "Library",
+  "name": "Library",
+  "contains": {
+    "@id": "http://example.org/graphs/books",
+    "@graph": {
+      "@id": "http://example.org/library/the-republic",
+      "@type": "Book",
+      "creator": "Plato",
+      "title": "The Republic",
       "contains": {
-        "@id": "http://example.org/graphs/books",
-        "@graph": {
-          "@id": "http://example.org/library/the-republic",
-          "@type": "Book",
-          "creator": "Plato",
-          "title": "The Republic",
-          "contains": {
-            "@id": "http://example.org/library/the-republic#introduction",
-            "@type": "Chapter",
-            "description": "An introductory chapter on The Republic.",
-            "title": "The Introduction"
-          }
-        }
+        "@id": "http://example.org/library/the-republic#introduction",
+        "@type": "Chapter",
+        "description": "An introductory chapter on The Republic.",
+        "title": "The Introduction"
       }
     }
-  ]
+  }
 }

--- a/tests/frame/0055-out.jsonld
+++ b/tests/frame/0055-out.jsonld
@@ -1,13 +1,11 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "@type": "ex:Type1",
-    "ex:mixedlist": {
-      "@list": [
-        {"@id": "ex:Sub2", "@type": "ex:Type2"},
-        "literal1"
-      ]
-    }
-  }]
+  "@id": "ex:Sub1",
+  "@type": "ex:Type1",
+  "ex:mixedlist": {
+    "@list": [
+      {"@id": "ex:Sub2", "@type": "ex:Type2"},
+      "literal1"
+    ]
+  }
 }

--- a/tests/frame/0060-out.jsonld
+++ b/tests/frame/0060-out.jsonld
@@ -2,12 +2,8 @@
   "@context": {
     "ex": "http://www.example.com/#"
   },
-  "@graph": [
-    {
-      "@id": "http://example/outer",
-      "@type": "ex:Thing",
-      "ex:embed1": {"@id": "http://example/embedded", "ex:name": "Embedded"},
-      "ex:embed2": {"@id": "http://example/embedded"}
-    }
-  ]
+  "@id": "http://example/outer",
+  "@type": "ex:Thing",
+  "ex:embed1": {"@id": "http://example/embedded", "ex:name": "Embedded"},
+  "ex:embed2": {"@id": "http://example/embedded"}
 }

--- a/tests/frame/g002-out.jsonld
+++ b/tests/frame/g002-out.jsonld
@@ -3,26 +3,24 @@
     "dcterms": "http://purl.org/dc/terms/",
     "ex": "http://example.org/vocab#"
   },
-  "@graph": [{
-    "@id": "http://example.org/test/#library",
-    "@type": "ex:Library",
+  "@id": "http://example.org/test/#library",
+  "@type": "ex:Library",
+  "ex:contains": {
+    "@id": "http://example.org/test#book",
+    "@type": "ex:Book",
+    "dcterms:contributor": "Writer",
+    "dcterms:title": "My Book",
     "ex:contains": {
-      "@id": "http://example.org/test#book",
-      "@type": "ex:Book",
-      "dcterms:contributor": "Writer",
-      "dcterms:title": "My Book",
-      "ex:contains": {
-        "@id": "http://example.org/test#chapter",
-        "@type": "ex:Chapter",
-        "dcterms:description": "Fun",
-        "dcterms:title": "Chapter One"
-      },
-      "ex:bookmark": {
-        "@id": "http://example.org/test#chapter",
-        "@type": "ex:Chapter",
-        "dcterms:description": "Fun",
-        "dcterms:title": "Chapter One"
-      }
+      "@id": "http://example.org/test#chapter",
+      "@type": "ex:Chapter",
+      "dcterms:description": "Fun",
+      "dcterms:title": "Chapter One"
+    },
+    "ex:bookmark": {
+      "@id": "http://example.org/test#chapter",
+      "@type": "ex:Chapter",
+      "dcterms:description": "Fun",
+      "dcterms:title": "Chapter One"
     }
-  }]
+  }
 }

--- a/tests/frame/g003-out.jsonld
+++ b/tests/frame/g003-out.jsonld
@@ -3,23 +3,21 @@
     "dcterms": "http://purl.org/dc/terms/",
     "ex": "http://example.org/vocab#"
   },
-  "@graph": [{
-    "@id": "http://example.org/test/#library",
-    "@type": "ex:Library",
+  "@id": "http://example.org/test/#library",
+  "@type": "ex:Library",
+  "ex:contains": {
+    "@id": "http://example.org/test#book",
+    "@type": "ex:Book",
+    "dcterms:contributor": "Writer",
+    "dcterms:title": "My Book about a library",
     "ex:contains": {
-      "@id": "http://example.org/test#book",
-      "@type": "ex:Book",
-      "dcterms:contributor": "Writer",
-      "dcterms:title": "My Book about a library",
-      "ex:contains": {
-        "@id": "http://example.org/test#chapter",
-        "@type": "ex:Chapter",
-        "dcterms:description": "Fun",
-        "dcterms:title": "Chapter One"
-      },
-      "ex:topic": {
-        "@id": "http://example.org/test/#library"
-      }
+      "@id": "http://example.org/test#chapter",
+      "@type": "ex:Chapter",
+      "dcterms:description": "Fun",
+      "dcterms:title": "Chapter One"
+    },
+    "ex:topic": {
+      "@id": "http://example.org/test/#library"
     }
-  }]
+  }
 }

--- a/tests/frame/g004-out.jsonld
+++ b/tests/frame/g004-out.jsonld
@@ -3,23 +3,21 @@
     "dcterms": "http://purl.org/dc/terms/",
     "ex": "http://example.org/vocab#"
   },
-  "@graph": [{
-    "@id": "http://example.org/test/#library",
-    "@type": "ex:Library",
+  "@id": "http://example.org/test/#library",
+  "@type": "ex:Library",
+  "ex:contains": {
+    "@id": "http://example.org/test#book",
+    "@type": "ex:Book",
+    "dcterms:contributor": "Writer",
+    "dcterms:title": "My Book about a library",
     "ex:contains": {
-      "@id": "http://example.org/test#book",
-      "@type": "ex:Book",
-      "dcterms:contributor": "Writer",
-      "dcterms:title": "My Book about a library",
-      "ex:contains": {
-        "@id": "http://example.org/test#chapter",
-        "@type": "ex:Chapter",
-        "dcterms:description": "Fun",
-        "dcterms:title": "Chapter One",
-        "ex:topic": {
-          "@id": "http://example.org/test/#library"
-        }
+      "@id": "http://example.org/test#chapter",
+      "@type": "ex:Chapter",
+      "dcterms:description": "Fun",
+      "dcterms:title": "Chapter One",
+      "ex:topic": {
+        "@id": "http://example.org/test/#library"
       }
     }
-  }]
+  }
 }

--- a/tests/frame/g006-out.jsonld
+++ b/tests/frame/g006-out.jsonld
@@ -3,46 +3,42 @@
     "dcterms": "http://purl.org/dc/terms/",
     "ex": "http://example.org/vocab#"
   },
-  "@graph": [
+  "@id": "http://example.org/town/#123",
+  "@type": "ex:Town",
+  "ex:name": "My town",
+  "ex:hasLibrary": [
     {
-      "@id": "http://example.org/town/#123",
-      "@type": "ex:Town",
-      "ex:name": "My town",
-      "ex:hasLibrary": [
-        {
-          "@id": "http://example.org/test/#library",
-          "@type": "ex:Library",
-          "ex:name": "My local library",
-          "ex:contains": {
-            "@id": "http://example.org/test#book",
-            "@type": "ex:Book",
-            "dcterms:contributor": "Writer",
-            "dcterms:title": "My Book about a library",
-            "ex:contains": {
-              "@id": "http://example.org/test#chapter",
-              "@type": "ex:Chapter",
-              "dcterms:description": "Fun",
-              "dcterms:title": "Chapter One",
-              "ex:topic": [
-                {
-                  "@id": "http://example.org/test/#library"
-                },
-                {
-                  "@id": "http://example.org/test/#library2",
-                  "@type": "ex:Library",
-                  "ex:name": "Another library"
-                }
-              ]
+      "@id": "http://example.org/test/#library",
+      "@type": "ex:Library",
+      "ex:name": "My local library",
+      "ex:contains": {
+        "@id": "http://example.org/test#book",
+        "@type": "ex:Book",
+        "dcterms:contributor": "Writer",
+        "dcterms:title": "My Book about a library",
+        "ex:contains": {
+          "@id": "http://example.org/test#chapter",
+          "@type": "ex:Chapter",
+          "dcterms:description": "Fun",
+          "dcterms:title": "Chapter One",
+          "ex:topic": [
+            {
+              "@id": "http://example.org/test/#library"
+            },
+            {
+              "@id": "http://example.org/test/#library2",
+              "@type": "ex:Library",
+              "ex:name": "Another library"
             }
-          }
-        },
-        {
-          "@id": "http://example.org/test/#library2",
-          "@type": "ex:Library",
-          "ex:contains": null,
-          "ex:name": "Another library"
+          ]
         }
-      ]
+      }
+    },
+    {
+      "@id": "http://example.org/test/#library2",
+      "@type": "ex:Library",
+      "ex:contains": null,
+      "ex:name": "Another library"
     }
   ]
 }

--- a/tests/frame/g007-out.jsonld
+++ b/tests/frame/g007-out.jsonld
@@ -3,87 +3,83 @@
     "dcterms": "http://purl.org/dc/terms/",
     "ex": "http://example.org/vocab#"
   },
-  "@graph": [
-    {
-      "@id": "http://example.org/test/#library",
-      "@type": "ex:Library",
-      "ex:contains": {
-        "@id": "http://example.org/test#book",
-        "@type": "ex:Book",
-        "dcterms:contributor": "Writer",
-        "dcterms:title": "My Book",
-        "ex:contains": [
+  "@id": "http://example.org/test/#library",
+  "@type": "ex:Library",
+  "ex:contains": {
+    "@id": "http://example.org/test#book",
+    "@type": "ex:Book",
+    "dcterms:contributor": "Writer",
+    "dcterms:title": "My Book",
+    "ex:contains": [
+      {
+        "@id": "http://example.org/test#chapter",
+        "@type": "ex:Chapter",
+        "dcterms:description": "Fun",
+        "dcterms:title": "Chapter One",
+        "ex:topic": [
           {
-            "@id": "http://example.org/test#chapter",
-            "@type": "ex:Chapter",
-            "dcterms:description": "Fun",
-            "dcterms:title": "Chapter One",
-            "ex:topic": [
-              {
-                "@id": "http://example.org/test#subject1",
-                "@type": "ex:Topic",
-                "dcterms:description": "Topic 1"
-              },
-              {
-                "@id": "http://example.org/test#subject2",
-                "@type": "ex:Topic",
-                "dcterms:description": "Topic 2"
-              },
-              {
-                "@id": "http://example.org/test#subject3",
-                "@type": "ex:Topic",
-                "dcterms:description": "Topic 3"
-              }
-            ]
+            "@id": "http://example.org/test#subject1",
+            "@type": "ex:Topic",
+            "dcterms:description": "Topic 1"
           },
           {
-            "@id": "http://example.org/test#chapter2",
-            "@type": "ex:Chapter",
-            "dcterms:description": "More Fun",
-            "dcterms:title": "Chapter Two",
-            "ex:topic": [
-              {
-                "@id": "http://example.org/test#subject1",
-                "@type": "ex:Topic",
-                "dcterms:description": "Topic 1"
-              },
-              {
-                "@id": "http://example.org/test#subject4",
-                "@type": "ex:Topic",
-                "dcterms:description": "Topic 4"
-              },
-              {
-                "@id": "http://example.org/test#subject5",
-                "@type": "ex:Topic",
-                "dcterms:description": "Topic 5"
-              }
-            ]
+            "@id": "http://example.org/test#subject2",
+            "@type": "ex:Topic",
+            "dcterms:description": "Topic 2"
+          },
+          {
+            "@id": "http://example.org/test#subject3",
+            "@type": "ex:Topic",
+            "dcterms:description": "Topic 3"
           }
-        ],
-        "ex:bookmark": {
-          "@id": "http://example.org/test#chapter",
-          "@type": "ex:Chapter",
-          "dcterms:description": "Fun",
-          "dcterms:title": "Chapter One",
-          "ex:topic": [
-            {
-              "@id": "http://example.org/test#subject1",
-              "@type": "ex:Topic",
-              "dcterms:description": "Topic 1"
-            },
-            {
-              "@id": "http://example.org/test#subject2",
-              "@type": "ex:Topic",
-              "dcterms:description": "Topic 2"
-            },
-            {
-              "@id": "http://example.org/test#subject3",
-              "@type": "ex:Topic",
-              "dcterms:description": "Topic 3"
-            }
-          ]
-        }
+        ]
+      },
+      {
+        "@id": "http://example.org/test#chapter2",
+        "@type": "ex:Chapter",
+        "dcterms:description": "More Fun",
+        "dcterms:title": "Chapter Two",
+        "ex:topic": [
+          {
+            "@id": "http://example.org/test#subject1",
+            "@type": "ex:Topic",
+            "dcterms:description": "Topic 1"
+          },
+          {
+            "@id": "http://example.org/test#subject4",
+            "@type": "ex:Topic",
+            "dcterms:description": "Topic 4"
+          },
+          {
+            "@id": "http://example.org/test#subject5",
+            "@type": "ex:Topic",
+            "dcterms:description": "Topic 5"
+          }
+        ]
       }
+    ],
+    "ex:bookmark": {
+      "@id": "http://example.org/test#chapter",
+      "@type": "ex:Chapter",
+      "dcterms:description": "Fun",
+      "dcterms:title": "Chapter One",
+      "ex:topic": [
+        {
+          "@id": "http://example.org/test#subject1",
+          "@type": "ex:Topic",
+          "dcterms:description": "Topic 1"
+        },
+        {
+          "@id": "http://example.org/test#subject2",
+          "@type": "ex:Topic",
+          "dcterms:description": "Topic 2"
+        },
+        {
+          "@id": "http://example.org/test#subject3",
+          "@type": "ex:Topic",
+          "dcterms:description": "Topic 3"
+        }
+      ]
     }
-  ]
+  }
 }

--- a/tests/frame/g008-out.jsonld
+++ b/tests/frame/g008-out.jsonld
@@ -4,92 +4,88 @@
     "ex": "http://example.org/vocab#",
     "ex:relatesTo": {"@type": "@id"}
   },
-  "@graph": [
-    {
-      "@id": "http://example.org/test/#library",
-      "@type": "ex:Library",
-      "ex:contains": {
-        "@id": "http://example.org/test#book",
-        "@type": "ex:Book",
-        "dcterms:contributor": "Writer",
-        "dcterms:title": "My Book",
-        "ex:contains": [
+  "@id": "http://example.org/test/#library",
+  "@type": "ex:Library",
+  "ex:contains": {
+    "@id": "http://example.org/test#book",
+    "@type": "ex:Book",
+    "dcterms:contributor": "Writer",
+    "dcterms:title": "My Book",
+    "ex:contains": [
+      {
+        "@id": "http://example.org/test#chapter",
+        "@type": "ex:Chapter",
+        "dcterms:description": "Fun",
+        "dcterms:title": "Chapter One",
+        "dcterms:subject": {"@id": "http://example.org/test/#library"},
+        "ex:topic": [
           {
-            "@id": "http://example.org/test#chapter",
-            "@type": "ex:Chapter",
-            "dcterms:description": "Fun",
-            "dcterms:title": "Chapter One",
-            "dcterms:subject": {"@id": "http://example.org/test/#library"},
-            "ex:topic": [
-              {
-                "@id": "http://example.org/test#subject1",
-                "@type": "ex:Topic",
-                "dcterms:description": "Topic 1",
-                "ex:relatesTo": "http://example.org/test/#library"
-              },
-              {
-                "@id": "http://example.org/test#subject2",
-                "@type": "ex:Topic",
-                "dcterms:description": "Topic 2"
-              },
-              {
-                "@id": "http://example.org/test#subject3",
-                "@type": "ex:Topic",
-                "dcterms:description": "Topic 3"
-              }
-            ]
+            "@id": "http://example.org/test#subject1",
+            "@type": "ex:Topic",
+            "dcterms:description": "Topic 1",
+            "ex:relatesTo": "http://example.org/test/#library"
           },
           {
-            "@id": "http://example.org/test#chapter2",
-            "@type": "ex:Chapter",
-            "dcterms:description": "More Fun",
-            "dcterms:title": "Chapter Two",
-            "ex:topic": [
-              {
-                "@id": "http://example.org/test#subject1",
-                "@type": "ex:Topic",
-                "dcterms:description": "Topic 1",
-                "ex:relatesTo": "http://example.org/test/#library"
-              },
-              {
-                "@id": "http://example.org/test#subject4",
-                "@type": "ex:Topic",
-                "dcterms:description": "Topic 4"
-              },
-              {
-                "@id": "http://example.org/test#subject5",
-                "@type": "ex:Topic",
-                "dcterms:description": "Topic 5"
-              }
-            ]
+            "@id": "http://example.org/test#subject2",
+            "@type": "ex:Topic",
+            "dcterms:description": "Topic 2"
+          },
+          {
+            "@id": "http://example.org/test#subject3",
+            "@type": "ex:Topic",
+            "dcterms:description": "Topic 3"
           }
-        ],
-        "ex:bookmark": {
-          "@id": "http://example.org/test#chapter",
-          "@type": "ex:Chapter",
-          "dcterms:description": "Fun",
-          "dcterms:title": "Chapter One",
-          "dcterms:subject": {"@id": "http://example.org/test/#library"},
-          "ex:topic": [
-            {
-              "@id": "http://example.org/test#subject1",
-              "@type": "ex:Topic",
-              "dcterms:description": "Topic 1",
-              "ex:relatesTo": "http://example.org/test/#library"
-            },
-            {
-              "@id": "http://example.org/test#subject2",
-              "@type": "ex:Topic",
-              "dcterms:description": "Topic 2"
-            },
-            {
-              "@id": "http://example.org/test#subject3",
-              "@type": "ex:Topic",
-              "dcterms:description": "Topic 3"
-            }
-          ]
-        }
+        ]
+      },
+      {
+        "@id": "http://example.org/test#chapter2",
+        "@type": "ex:Chapter",
+        "dcterms:description": "More Fun",
+        "dcterms:title": "Chapter Two",
+        "ex:topic": [
+          {
+            "@id": "http://example.org/test#subject1",
+            "@type": "ex:Topic",
+            "dcterms:description": "Topic 1",
+            "ex:relatesTo": "http://example.org/test/#library"
+          },
+          {
+            "@id": "http://example.org/test#subject4",
+            "@type": "ex:Topic",
+            "dcterms:description": "Topic 4"
+          },
+          {
+            "@id": "http://example.org/test#subject5",
+            "@type": "ex:Topic",
+            "dcterms:description": "Topic 5"
+          }
+        ]
       }
+    ],
+    "ex:bookmark": {
+      "@id": "http://example.org/test#chapter",
+      "@type": "ex:Chapter",
+      "dcterms:description": "Fun",
+      "dcterms:title": "Chapter One",
+      "dcterms:subject": {"@id": "http://example.org/test/#library"},
+      "ex:topic": [
+        {
+          "@id": "http://example.org/test#subject1",
+          "@type": "ex:Topic",
+          "dcterms:description": "Topic 1",
+          "ex:relatesTo": "http://example.org/test/#library"
+        },
+        {
+          "@id": "http://example.org/test#subject2",
+          "@type": "ex:Topic",
+          "dcterms:description": "Topic 2"
+        },
+        {
+          "@id": "http://example.org/test#subject3",
+          "@type": "ex:Topic",
+          "dcterms:description": "Topic 3"
+        }
+      ]
     }
-  ]
+  }
 }

--- a/tests/frame/g009-out.jsonld
+++ b/tests/frame/g009-out.jsonld
@@ -7,31 +7,27 @@
     },
     "shouldExist": "ex:shouldExist"
   },
-  "@graph": [
+  "@id": "ex:root",
+  "@type": "ex:TreeRoot",
+  "embed": [
     {
-      "@id": "ex:root",
-      "@type": "ex:TreeRoot",
+      "@id": "ex:node-d1-with-leaf",
       "embed": [
         {
-          "@id": "ex:node-d1-with-leaf",
+          "@id": "ex:leaf",
+          "shouldExist": "shows when embedded"
+        }
+      ]
+    },
+    {
+      "@id": "ex:node-d1-with-node",
+      "embed": [
+        {
+          "@id": "ex:node-d2-with-leaf",
           "embed": [
             {
               "@id": "ex:leaf",
               "shouldExist": "shows when embedded"
-            }
-          ]
-        },
-        {
-          "@id": "ex:node-d1-with-node",
-          "embed": [
-            {
-              "@id": "ex:node-d2-with-leaf",
-              "embed": [
-                {
-                  "@id": "ex:leaf",
-                  "shouldExist": "shows when embedded"
-                }
-              ]
             }
           ]
         }

--- a/tests/frame/ra01-out.jsonld
+++ b/tests/frame/ra01-out.jsonld
@@ -1,8 +1,6 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "@type": "ex:Type",
-    "ex:p": "foo"
-  }]
+  "@id": "ex:Sub1",
+  "@type": "ex:Type",
+  "ex:p": "foo"
 }

--- a/tests/frame/ra02-out.jsonld
+++ b/tests/frame/ra02-out.jsonld
@@ -1,8 +1,6 @@
 {
   "@context": {"ex": "http://example.org/"},
-  "@graph": [{
-    "@id": "ex:Sub1",
-    "@type": "ex:Type",
-    "ex:p": "foo"
-  }]
+  "@id": "ex:Sub1",
+  "@type": "ex:Type",
+  "ex:p": "foo"
 }


### PR DESCRIPTION
* Update tests for lazy-evaluation of processingMode.

The major implication is that a top-level `@graph` is only output for a single node if processingMode is set explicitly to `json-ld-1.0`, previously it would be output unless processingMode is set explicitly to `json-ld-1.1`.

For w3c/json-ld-api#161.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/76.html" title="Last updated on Oct 18, 2019, 8:53 PM UTC (5f31ce0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/76/3ffe3a3...5f31ce0.html" title="Last updated on Oct 18, 2019, 8:53 PM UTC (5f31ce0)">Diff</a>