### PR TITLE
Fix expansion of link template variable json_file, regenerate html.

### DIFF
--- a/tests/frame-manifest.html
+++ b/tests/frame-manifest.html
@@ -16,7 +16,7 @@ Framing
 </p>
 <h1>Framing</h1>
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
-<a href="json_file">frame-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
+<a href="frame-manifest.jsonld">frame-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
 <p>The JSON-LD Test Suite is a set of tests that can
 be used to verify JSON-LD Processor conformance to the set of specifications

--- a/tests/manifest.html
+++ b/tests/manifest.html
@@ -16,7 +16,7 @@ JSON-LD Test Suite
 </p>
 <h1>JSON-LD Test Suite</h1>
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
-<a href="json_file">manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
+<a href="manifest.jsonld">manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
 <p>The JSON-LD Test Suite is a set of tests that can
 be used to verify JSON-LD Processor conformance to the set of specifications

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -8,7 +8,7 @@
     %meta{"http-equiv" => "Content-Type", :content => "text/html;charset=utf-8"}
     %title
       = manifest['name']
-    %link{rel: "alternate", href: json_file}
+    %link{rel: "alternate", href: "#{json_file}"}
     %link{rel: "stylesheet", href: "https://www.w3.org/StyleSheets/TR/base"}
   %body
     %p
@@ -17,7 +17,7 @@
     %h1<=manifest['name']
     :markdown
       This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
-      [#{json_file}](json_file). The manifest vocabulary is described in the [JSON-LD Test Vocabulary](vocab.html) ([JSON-LD](vocab.jsonld), [Turtle](vocab.ttl)) and is based on the [RDF Test Vocabulary](http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/).
+      [#{json_file}](#{json_file}). The manifest vocabulary is described in the [JSON-LD Test Vocabulary](vocab.html) ([JSON-LD](vocab.jsonld), [Turtle](vocab.ttl)) and is based on the [RDF Test Vocabulary](http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/).
 
       The JSON-LD Test Suite is a set of tests that can
       be used to verify JSON-LD Processor conformance to the set of specifications


### PR DESCRIPTION
The links e.g. to manifest.jsonld were giving a 404, pointing to a file `json_file`,
It looks like the template was missing the necessary details to expand the variable json_file.

You can currently observe the behavior by clicking the `manifest.jsonld` links at the following.
* [json-ld-api-tests](https://w3c.github.io/json-ld-api/tests/)
* [json-framing-ld-tests](https://w3c.github.io/json-ld-framing/tests/)
