### PR TITLE
Text and tests for default values of `@type`.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ruby-rdf/json-ld.git
-  revision: 565f89265c1fc06d2fd5b761bdbf95b905065d3a
+  revision: 8d9cec0d7cceb434d8e18d878776495e8d1fff35
   branch: develop
   specs:
     json-ld (3.0.2)
@@ -33,10 +33,10 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     htmlentities (4.3.4)
-    i18n (1.6.0)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     json-canonicalization (0.1.0)
-    json-ld-preloaded (3.0.4)
+    json-ld-preloaded (3.0.6)
       json-ld (~> 3.0)
       multi_json (~> 1.12)
       rdf (~> 3.0)
@@ -73,7 +73,7 @@ GEM
       sparql (~> 3.0)
       sparql-client (~> 3.0)
     mini_portile2 (2.4.0)
-    multi_json (1.13.1)
+    multi_json (1.14.1)
     net-http-persistent (3.1.0)
       connection_pool (~> 2.2)
     nokogiri (1.10.4)
@@ -82,7 +82,7 @@ GEM
       nokogiri
     public_suffix (4.0.1)
     rack (2.0.7)
-    rake (12.3.3)
+    rake (13.0.0)
     rdf (3.0.12)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
@@ -134,7 +134,7 @@ GEM
     rdf-turtle (3.0.6)
       ebnf (~> 1.1)
       rdf (~> 3.0)
-    rdf-vocab (3.0.10)
+    rdf-vocab (3.0.12)
       rdf (~> 3.0, >= 3.0.11)
     rdf-xsd (3.0.1)
       rdf (~> 3.0)
@@ -160,8 +160,8 @@ GEM
       rdf (~> 3.0)
     sxp (1.0.2)
       rdf (~> 3.0)
-    temple (0.8.1)
-    tilt (2.0.9)
+    temple (0.8.2)
+    tilt (2.0.10)
 
 PLATFORMS
   ruby

--- a/index.html
+++ b/index.html
@@ -648,6 +648,99 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
       </pre>
     </aside>
 
+    <p>Default values may also be used for `@type`, similar to other properties.
+      In this case, a matched <a>node object</a> without an `@type` will take the
+      value of the <a>default object</a> from the <a>frame</a>.
+      The <a>default object</a> has a value which is a single <a>IRI</a>.
+      If multiple <a>IRIs</a> are specified, only the first will be used as the default type.</p>
+
+    <p>The frame matches objects having specific property values,
+      and provides defaults for `@type` for matched objects.</p>
+    <pre id="sample-library-frame-with-default-type"
+         class="example frame nohighlight" data-transform="updateExample"
+         data-content-type="application/ld+json;profile=http://www.w3.org/ns/json-ld#framed"
+         data-frame-for="Typeless library objects"
+         title="Sample library frame with @default type">
+    <!--
+    {
+      "@context": {"@vocab": "http://example.org/"},
+      "@type": "Library",
+      "contains": {
+        ****"@type": {"@default": "Book"}****,
+        "creator": "Plato",
+        "contains": {
+          ****"@type": {"@default": "Chapter"}****,
+          "description": "An introductory chapter on The Republic."
+        }
+      }
+    }
+    -->
+    </pre>
+
+    <p>Data missing specific values for `@type`, but which matches based on
+      other property values.</p>
+    <pre id="flattened-library-objects-without-type"
+         class="example input" data-transform="updateExample"
+         title="Typeless library objects">
+    <!--
+    {
+      "@context": {
+        "@vocab": "http://example.org/",
+        "contains": {"@type": "@id"}
+      },
+      "@graph": [{
+        "@id": "http://example.org/library",
+        "@type": "Library",
+        "contains": "http://example.org/library/the-republic"
+      }, {
+        "@id": "http://example.org/library/the-republic",
+        "creator": "Plato",
+        "title": "The Republic",
+        "contains": "http://example.org/library/the-republic#introduction"
+      }, {
+        "@id": "http://example.org/library/the-republic#introduction",
+        "description": "An introductory chapter on The Republic.",
+        "title": "The Introduction"
+      }]
+    }
+    -->
+    </pre>
+
+    <aside class="example ds-selector-tabs"
+           title="Sample library output with @default type">
+      <div class="selectors">
+        <a class="playground"
+           data-result-for="#flattened-library-objects-without-type"
+           data-frame="#sample-library-frame-with-default-type"
+           target="_blank"></a>
+      </div>
+      <pre class="selected result nohighlight" data-transform="updateExample"
+           data-frame="Sample library frame with @default value"
+           data-result-for="Flattened library objects">
+      <!--
+      {
+        "@context": {"@vocab": "http://example.org/"},
+        "@graph": [{
+          "@id": "http://example.org/library",
+          "@type": "Library",
+          "contains": {
+            "@id": "http://example.org/library/the-republic",
+            ****"@type": "Book"****,
+            "contains": {
+              "@id": "http://example.org/library/the-republic#introduction",
+              ****"@type": "Chapter"****,
+              "description": "An introductory chapter on The Republic.",
+              "title": "The Introduction"
+            },
+            "creator": "Plato",
+            "description": "A great book.",
+            "title": "The Republic"
+          }
+        }]
+      }
+      -->
+      </pre>
+    </aside>
   </section>
 
   <section class="informative">

--- a/index.html
+++ b/index.html
@@ -580,7 +580,9 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
     <p>A frame may specify properties that don't exist in an input file. If the
       <a>explicit inclusion flag</a> is <code>false</code>, the framing algorithm
       will add a property and value to the result. The <code>@default</code> property
-      in a <a>node object</a> or <a>value object</a> provides a default value to use in the resulting
+      in a <a>node object</a> or <a>value object</a>,
+      <span class="changed">or as a value of `@type`</span>,
+      provides a default value to use in the resulting
       output document. If there is no <code>@default</code> value, the property will be output
       with a <code>null</code> value. (See <a href="#omit-default-flag" class="sectionRef"></a>
       for ways to avoid this).</p>
@@ -1500,6 +1502,8 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
       <span class="changed">an <a>absolute IRI</a></span>,
       <a>array</a> containing only an empty <a>map</a>,
       <span class="changed">or an array of <a>absolute IRIs</a></span>.
+      <span class="changed">Values of `@type` MAY also be a <a>map</a> with
+        a `@default` entry, whose values are restricted by be <a>IRIs</a></span>.
       <a>Processors</a> MUST preserve this value when expanding.</li>
     <li>Framing either operates on the merged node definitions contained in
       the input document, or on the <a>default graph</a> depending on if the
@@ -1675,7 +1679,9 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
             </ol>
           </li>
 
-          <li>For each non-<a>keyword</a> <var>property</var> and <var>objects</var> in <var>frame</var> that is not in <var>output</var>:
+          <li>For each non-<a>keyword</a> <var>property</var> and <var>objects</var> in <var>frame</var>
+            <span class="changed">(other than `@type)</span>
+            that is not in <var>output</var>:
             <ol>
               <li>Let <var>item</var> be the first element in <var>objects</var>, which MUST be a <a>frame object</a>.</li>
               <li>Set <var>property frame</var> to the first item in <var>objects</var> or a newly created <a>frame object</a> if value is <var>objects</var>.
@@ -1811,6 +1817,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
           <li><var>property</var> matches if the <code>@type</code> property in frame includes any <a>IRI</a> in <var>values</var>.</li>
           <li>Otherwise, <var>property</var> matches if <var>values</var> is not empty and the <code>@type</code> property in <var>frame</var> is <code><a>wildcard</a></code>.</li>
           <li>Otherwise, <var>property</var> matches if <var>values</var> is empty and the <code>@type</code> property in <var>frame</var> is <code><a>match none</a></code>.</li>
+          <li>Otherwise, <var>property</var> matches if the <code>@type</code> property in frame is a <a>default object</a>.</li>
           <li>Otherwise, <var>property</var> does not match.</li>
         </ol>
       </li>
@@ -2295,6 +2302,8 @@ becomes a W3C Recommendation.</p>
       <a>object embed flag</a> in favor of <code>@once</code>.</li>
     <li>The <a>processing mode</a> is now implicitly `json-ld-1.1`, unless set
       explicitly to `json-ld-1.0`.</li>
+    <li>In a frame `@type` can have a default value, which is not used for
+      frame matching purposes.</li>
   </ul>
 </section>
 

--- a/tests/frame-manifest.html
+++ b/tests/frame-manifest.html
@@ -2086,6 +2086,38 @@ Test t0063 Using @null in @default.
 </dd>
 </dl>
 </dd>
+<dt id='t0064'>
+Test t0064 Using @default in @type.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0064</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:FrameTest</dd>
+<dt>Purpose</dt>
+<dd>@type may have a default value.</dd>
+<dt>input</dt>
+<dd>
+<a href='frame/0064-in.jsonld'>frame/0064-in.jsonld</a>
+</dd>
+<dt>frame</dt>
+<dd>
+<a href='frame/0064-frame.jsonld'>frame/0064-frame.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='frame/0064-out.jsonld'>frame/0064-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='teo01'>
 Test teo01 @embed true/false
 </dt>

--- a/tests/frame-manifest.jsonld
+++ b/tests/frame-manifest.jsonld
@@ -567,6 +567,15 @@
       "expect": "frame/0063-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0064",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Using @default in @type.",
+      "purpose": "@type may have a default value.",
+      "input": "frame/0064-in.jsonld",
+      "frame": "frame/0064-frame.jsonld",
+      "expect": "frame/0064-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#teo01",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "@embed true/false",

--- a/tests/frame/0064-frame.jsonld
+++ b/tests/frame/0064-frame.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {"ex": "http://example.org/"},
+  "@type": {"@default": "ex:Foo"},
+  "ex:foo": "bar"
+}

--- a/tests/frame/0064-in.jsonld
+++ b/tests/frame/0064-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {"ex": "http://example.org/"},
+  "@id": "ex:Sub1",
+  "ex:foo": "bar"
+}

--- a/tests/frame/0064-out.jsonld
+++ b/tests/frame/0064-out.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {"ex": "http://example.org/"},
+  "@id": "ex:Sub1",
+  "@type": "ex:Foo",
+  "ex:foo": "bar"
+}


### PR DESCRIPTION
For #74.

Also requires changes to expand to allow a default object to be a value of `@type` when framing.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/78.html" title="Last updated on Oct 21, 2019, 6:22 PM UTC (767bbb4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/78/02a0aef...767bbb4.html" title="Last updated on Oct 21, 2019, 6:22 PM UTC (767bbb4)">Diff</a>