### PR TITLE
Update baseIri to json-ld-framing

### DIFF
--- a/tests/frame-manifest.html
+++ b/tests/frame-manifest.html
@@ -92,7 +92,7 @@ to the <a href="mailto:json-ld-wg@w3.org">JSON-LD Working Group mailing list</a>
   COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
 <dl>
 <dt>baseIri</dt>
-<dd>https://w3c.github.io/json-ld-api/tests/</dd>
+<dd>https://w3c.github.io/json-ld-framing/tests/</dd>
 </dl>
 <p>JSON-LD Framing tests.</p>
 <section>

--- a/tests/frame-manifest.jsonld
+++ b/tests/frame-manifest.jsonld
@@ -4,7 +4,7 @@
   "@type": "mf:Manifest",
   "name": "Framing",
   "description": "JSON-LD Framing tests.",
-  "baseIri": "https://w3c.github.io/json-ld-api/tests/",
+  "baseIri": "https://w3c.github.io/json-ld-framing/tests/",
   "sequence": [
     {
       "@id": "#t0001",


### PR DESCRIPTION
Update `baseIri` from `https://w3c.github.io/json-ld-api/tests/` to `https://w3c.github.io/json-ld-framing/tests/`.

But I'm wondering: wouldn't it make sense to use `https://w3c.github.io/json-ld-framing/tests/frame-manifest.html` as the base IRI, so that if we concat `baseIri` and `@id` we'd get resolvable URLs like https://w3c.github.io/json-ld-framing/tests/frame-manifest.html#t0001?

(And the same for the individual manifests in json-ld-api/tests.)