### PR TITLE
Improve omit graph flag example discussion

### DIFF
--- a/index.html
+++ b/index.html
@@ -648,8 +648,7 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
     <pre class="example result" data-transform="updateExample"
          data-frame="Sample library frame"
          data-result-for="Flattened library objects"
-         data-options="omitGraph=true"
-         title="Framed library objects with omitGraph set to false">
+         title="Framed library objects">
     <!--
     {
       "@context": {"@vocab": "http://example.org/"},
@@ -1869,10 +1868,14 @@ familiar with the basic RDF concepts [[RDF11-CONCEPTS]].</p>
 
     <p>The result is the same as the original <a href="#flattened-library-objects">Flattened library objects</a> example,
       but a `@graph` at the top-level.
-      The top-level object can be enclosed within `@graph` by setting the <a>processing mode</a> to `json-ld-1.0`.</p>
+      <a href="#example-5-framed-library-objects">Example 5</a> shows the results
+      with the <a>omit graph flag</a> set to `true`, which is the default value when
+      the <a>processing mode</a> is set to the default `json-ld-1.1`.
+      The top-level object can be enclosed within `@graph` by setting the <a>processing mode</a> to `json-ld-1.0`,
+      or by setting the <a>omit graph flag</a> to `false`.</p>
 
     <aside class="example ds-selector-tabs"
-           title="Framed library objects with @omitGraph">
+           title="Framed library objects with @omitGraph set to false">
       <div class="selectors">
         <a class="playground"
            data-result-for="#flattened-library-objects"


### PR DESCRIPTION
with reference to example 5, where the default `true` value is implied.

For #88.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/91.html" title="Last updated on Dec 23, 2019, 8:25 PM UTC (63a34f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/91/e212af6...63a34f8.html" title="Last updated on Dec 23, 2019, 8:25 PM UTC (63a34f8)">Diff</a>