### PR TITLE
Tests for #99: Framing matches on specified value

### DIFF
--- a/tests/frame-manifest.jsonld
+++ b/tests/frame-manifest.jsonld
@@ -576,6 +576,33 @@
       "expect": "frame/0064-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0065",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Match on value",
+      "purpose": "Value matching.",
+      "input": "frame/0065-in.jsonld",
+      "frame": "frame/0065-frame.jsonld",
+      "expect": "frame/0065-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#t0066",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Match on value reference",
+      "purpose": "Value reference matching.",
+      "input": "frame/0066-in.jsonld",
+      "frame": "frame/0066-frame.jsonld",
+      "expect": "frame/0066-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#t0067",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Match on list value",
+      "purpose": "List value matching.",
+      "input": "frame/0067-in.jsonld",
+      "frame": "frame/0067-frame.jsonld",
+      "expect": "frame/0067-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#teo01",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "@embed true/false",

--- a/tests/frame/0065-frame.jsonld
+++ b/tests/frame/0065-frame.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
+  "givenName": "John"
+}

--- a/tests/frame/0065-in.jsonld
+++ b/tests/frame/0065-in.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
+  "@graph": [
+    {
+      "@id": "JOHN",
+      "@type": "Person",
+      "givenName": "John"
+    },
+    {
+      "@id": "JANE",
+      "@type": "Person",
+      "givenName": "Jane"
+    }
+  ]
+}

--- a/tests/frame/0065-out.jsonld
+++ b/tests/frame/0065-out.jsonld
@@ -1,0 +1,9 @@
+
+{
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
+  "@id": "JOHN",
+  "@type": "Person",
+  "givenName": "John"
+}

--- a/tests/frame/0066-frame.jsonld
+++ b/tests/frame/0066-frame.jsonld
@@ -1,0 +1,7 @@
+
+{
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
+  "follows": { "@id": "https://schema.org/JANE" }
+}

--- a/tests/frame/0066-in.jsonld
+++ b/tests/frame/0066-in.jsonld
@@ -1,0 +1,20 @@
+
+{
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
+  "@graph": [
+    {
+      "@id": "JOHN",
+      "@type": "Person",
+      "givenName": "John",
+      "follows": { "@id": "https://schema.org/JANE" }
+    },
+    {
+      "@id": "JANE",
+      "@type": "Person",
+      "givenName": "Jane",
+      "follows": { "@id": "https://schema.org/JOHN" }
+    }
+  ]
+}

--- a/tests/frame/0066-out.jsonld
+++ b/tests/frame/0066-out.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
+  "@id": "JOHN",
+  "@type": "Person",
+  "givenName": "John",
+  "follows": {
+    "@id": "https://schema.org/JANE"
+  }
+}

--- a/tests/frame/0067-frame.jsonld
+++ b/tests/frame/0067-frame.jsonld
@@ -1,0 +1,11 @@
+
+{
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
+  "follows": {
+    "@list": [{
+      "@id": "https://schema.org/JANE"
+    }]
+  }
+}

--- a/tests/frame/0067-in.jsonld
+++ b/tests/frame/0067-in.jsonld
@@ -1,0 +1,40 @@
+
+{
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
+  "@graph": [
+    {
+      "@id": "JOHN",
+      "@type": "Person",
+      "givenName": "John",
+      "follows": {
+        "@list": [{
+          "@id": "https://schema.org/JANE"
+        }]
+      }
+    },
+    {
+      "@id": "JANE",
+      "@type": "Person",
+      "givenName": "Jane",
+      "follows": {
+        "@list": [{
+          "@id": "https://schema.org/JOHN"
+        }]
+      }
+    },
+    {
+      "@id": "ALICE",
+      "@type": "Person",
+      "givenName": "Alice",
+      "follows": {
+        "@list": [{
+          "@id": "https://schema.org/JOHN"
+        }, {
+          "@id": "https://schema.org/JANE"
+        }]
+      }
+    }
+  ]
+}

--- a/tests/frame/0067-out.jsonld
+++ b/tests/frame/0067-out.jsonld
@@ -1,0 +1,32 @@
+
+{
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
+  "@graph": [
+    {
+      "@id": "ALICE",
+      "@type": "Person",
+      "givenName": "Alice",
+      "follows": {
+        "@list": [
+          {
+            "@id": "https://schema.org/JANE"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "JOHN",
+      "@type": "Person",
+      "givenName": "John",
+      "follows": {
+        "@list": [
+          {
+            "@id": "https://schema.org/JANE"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I noticed a discrepancy between JSON-LD Playground and RDF Distiller regarding frame matching.

This PR adds 3 tests for frame matching on a specified value.

Fixes https://github.com/w3c/json-ld-framing/issues/99

Original issue here:

https://github.com/digitalbazaar/jsonld.js/issues/300

I created a fix for this in jsonld.js repo and the I'm hoping to commit the tests here.