### PR TITLE
Make a global JsonLd interface.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2582,9 +2582,8 @@
       as long as they generally use the same methods, arguments, and options
       and return the same results.</span></p>
 
-  <p class="note">Interfaces are not marked with the `[Exposed]`
-    <a data-cite="WEBIDL#dfn-extended-attribute">extended attribute</a>,
-    as this is currently quite browser specific.
+  <p class="note">Interfaces are marked `[Exposed=JsonLd]`,
+    which creates a global interface.
     The use of WebIDL in JSON-LD, while appropriate for use within browsers,
     is not limited to such use.</p>
 
@@ -2601,6 +2600,13 @@
       and processing is stopped.</p>
 
     <pre class="idl">
+      /*
+       * The JsonLd interface is created to expose the JsonLdProcessor interface.
+       */
+      [Global=JsonLd, Exposed=JsonLd]
+      interface JsonLd {};
+
+      [Exposed=JsonLd]
       interface JsonLdProcessor {
         constructor();
         static Promise&lt;JsonLdRecord> frame(
@@ -3145,9 +3151,9 @@ becomes a W3C Recommendation.</p>
       into the {{JsonLdProcessor}} processing steps.</li>
     <li>Remove the <var>graph stack</var> from <a>framing state</a>
       as being unnecessary.</li>
-    <li>Removed the `[Exposed=(Window,Worker)]`
-      <a data-cite="WEBIDL#dfn-extended-attribute">extended attribute</a>
-      from <a href="#the-application-programming-interface" class="sectionRef"></a> to address review suggestions.</li>
+    <li>Changed `[Exposed=(Window,Worker)]` to `[Exposed=JsonLd]`,
+      which is declared as a global interface in order to expose the {{JsonLdProcessor}} interface
+      for non-browser usage to address review suggestions.</li>
   </ul>
 </section>
 


### PR DESCRIPTION
This silences ReSpec, and is probably better than just removing [Exposed] altogether.

Thanks to @hober for the advice.

Matches w3c/json-ld-api#500.

CC/ @swickr @iherman


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/108.html" title="Last updated on Jun 26, 2020, 9:23 PM UTC (9bf3593)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/108/361f84a...9bf3593.html" title="Last updated on Jun 26, 2020, 9:23 PM UTC (9bf3593)">Diff</a>