### PR TITLE
Updates to accommodate ReSpec changes and subsequent issues found post-REC.

### DIFF
--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -9,7 +9,7 @@
     which is used for finding coercion mappings in the <a>active context</a>.</dd>
   <dt><dfn data-cite="JSON-LD11-API#dfn-active-subject">active subject</dfn></dt><dd>
     The currently active subject that the processor should use when processing.</dd>
-  <dt class="changed"><dfn data-cite="JSON-LD11-API#add-value">add value</dfn></dt>
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-add-value">add value</dfn></dt>
   <dd class="algorithm changed">
     Used as a macro within various algorithms as a way to add a <var>value</var>
     to an <a>entry</a> in a <a>map</a> (<var>object</var>) using a specified <var>key</var>.
@@ -38,7 +38,7 @@
       </li>
     </ol>
   </dd>
-  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-expicit-inclusion-flag">explicit inclusion flag</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-explicit-inclusion-flag">explicit inclusion flag</dfn></dt><dd>
     A flag specifying that for <a>properties</a> to be included in the output,
     they must be explicitly declared in the matching <a>frame</a>.</dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-framing-state">framing state</dfn></dt><dd>
@@ -78,7 +78,7 @@
     the <var>document relative</var> flag defaults to `false`,
     and the <var>vocab</var> flag defaults to `true`.
     <ol>
-      <li>Return the result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
+      <li>Return the result of using the <a data-cite="JSON-LD11-API#iri-expansion">IRI Expansion algorithm</a>,
         passing <var>active context</var>,
         <var>value</var>,
         <var>local context</var> (if supplied),

--- a/common/terms.html
+++ b/common/terms.html
@@ -188,7 +188,7 @@
     An embedded <a>context</a> is a context which appears
     as the <code>@context</code> <a>entry</a> of one of the following:
     a <a>node object</a>, a <a>value object</a>, a <a>graph object</a>, a <a>list object</a>,
-    a <a>set object</a>, the value of a <a>nested properties</a>,
+    a <a>set object</a>, the value of a <a>nested property</a>,
     or the value of an <a>expanded term definition</a>.
     Its value may be a <a>map</a> for a <a data-cite="JSON-LD11#dfn-context-definition">context definition</a>,
     as an <a>IRI</a>, or as an <a>array</a> combining either of the above.
@@ -230,7 +230,7 @@
     Note that <a>node objects</a> may have a <code>@graph</code> <a>entry</a>,
     but are not considered <a>graph objects</a> if they include any other <a>entries</a>.
     A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.
-    Note that a <a>node object</a> may also represent a <a>named graph</a> it it includes other properties.
+    Note that a <a>node object</a> may also represent a <a>named graph</a> if it includes other properties.
     See the <a data-cite="JSON-LD11#graph-objects">Graph Objects</a> section of JSON-LD 1.1 for a normative description.
   </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-id-map">id map</dfn></dt><dd class="changed">
@@ -302,7 +302,7 @@
     and normatively specified in the <a data-cite="JSON-LD11#keywords">Keywords</a> section of JSON-LD 1.1,
   </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-language-map">language map</dfn></dt><dd>
-    An <a>language map</a> is a <a>map</a> value of a <a>term</a>
+    A <a>language map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@language</code>,
     whose keys must be <a>strings</a> representing [[BCP47]] language codes
     and the values must be any of the following types:

--- a/common/typographical-conventions.html
+++ b/common/typographical-conventions.html
@@ -15,7 +15,7 @@
     A reference to a definition <em>in this document</em>
     is underlined and is also an active link to the definition itself. </dd>
   <dt><a data-lt="definition"><code>markup definition reference</code></a></dt><dd>
-    A references to a definition <em>in this document</em>,
+    References to a definition <em>in this document</em>,
     when the reference itself is also a markup, is underlined,
     red-orange monospace font, and is also an active link to the definition itself.</dd>
   <dt><a class="externalDFN">external definition reference</a></dt><dd>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <title>JSON-LD 1.1 Framing</title>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer></script>
+<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
 <script src="common/common.js" class="remove" defer></script>
 <script src="common/jsonld.js" class="remove"></script>
 <script class="remove">
@@ -116,22 +116,9 @@
           note:       "v1.0" }
       ],
 
-      // name of the WG
-      wg:           "JSON-LD Working Group",
+      group: "wg/json-ld",
+      wgPublicList:           "public-json-ld-wg",
 
-      // URI of the public WG page
-      wgURI:        "https://www.w3.org/2018/json-ld-wg/",
-
-      // name (with the @w3c.org) of the public mailing to which comments are due
-      wgPublicList: "public-json-ld-wg",
-
-      // URI of the patent status for this WG, for Rec-track documents
-      // !!!! IMPORTANT !!!!
-      // This is important for Rec-track documents, do not copy a patent URI from a random
-      // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
-      // Team Contact.
-      wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/107714/status",
-      processVersion: 2018,
       maxTocLevel: 4,
       alternateFormats: [ {uri: "json-ld11-framing.epub", label: "EPUB"} ]
   };
@@ -432,18 +419,14 @@
     <p>This document uses the following terms as defined in external specifications
       and defines terms specific to JSON-LD.</p>
 
-    <div data-include="common/terms.html"
-         data-oninclude="restrictReferences">
-    </div>
+    <div data-include="common/terms.html"></div>
 
   <section>
     <h4>Algorithm Terms</h4>
 
     <p>The Following terms are used within specific algorithms.</p>
 
-    <div data-include="common/algorithm-terms.html"
-         data-oninclude="restrictReferences">
-    </div>
+    <div data-include="common/algorithm-terms.html"></div>
   </section>
 </section>
 <section id="framing-keywords">
@@ -599,7 +582,8 @@
         <a class="playground"
            data-result-for="#flattened-library-objects"
            data-frame="#sample-library-frame"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected framed result" data-transform="updateExample"
            data-frame="Sample library frame"
@@ -701,7 +685,8 @@
         <a class="playground"
            data-result-for="#flattened-library-objects"
            data-frame="#library-frame-with-property-selection"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected framed result" data-transform="updateExample"
            data-frame="Library frame with property matching"
@@ -768,7 +753,8 @@
         <a class="playground"
            data-result-for="#flattened-library-objects"
            data-frame="#library-frame-with-wildcards"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected framed result" data-transform="updateExample"
            data-frame="Library frame with wildcard matching"
@@ -835,7 +821,8 @@
         <a class="playground"
            data-result-for="#flattened-library-objects"
            data-frame="#library-frame-with-absent-property"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected framed result" data-transform="updateExample"
            data-frame="Library frame with absent matching"
@@ -950,7 +937,8 @@
         <a class="playground"
            data-result-for="#multilingual-library-objects"
            data-frame="#library-frame-with-language-matching"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
        <!-- ignore as this won't match the input -->
       <pre class="selected framed result" data-transform="updateExample"
@@ -1014,7 +1002,8 @@
         <a class="playground"
            data-result-for="#flattened-library-objects"
            data-frame="#library-frame-with-id-matching"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected framed result" data-transform="updateExample"
            data-frame="Library frame with @id matching"
@@ -1075,7 +1064,8 @@
         <a class="playground"
            data-result-for="#flattened-library-objects"
            data-frame="#library-frame-with-array-id-matching"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected framed result" data-transform="updateExample"
            data-frame="Library frame with array @id matching"
@@ -1128,7 +1118,8 @@
         <a class="playground"
            data-result-for="#flattened-library-objects"
            data-frame="#empty-frame"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected framed result" data-transform="updateExample"
            data-frame="Empty frame"
@@ -1218,7 +1209,8 @@
         <a class="playground"
            data-result-for="#flattened-library-objects"
            data-frame="#sample-library-frame-with-default-value"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected framed result nohighlight" data-transform="updateExample"
            data-frame="Sample library frame with @default value"
@@ -1312,7 +1304,8 @@
         <a class="playground"
            data-result-for="#flattened-library-objects-without-type"
            data-frame="#sample-library-frame-with-default-type"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected result nohighlight" data-transform="updateExample"
            data-frame="Sample library frame with @default value"
@@ -1382,7 +1375,8 @@
           <a class="playground"
              data-result-for="#flattened-library-objects"
              data-frame="#sample-library-frame-with-implicit-embed-set-to-once"
-             target="_blank"></a>
+             target="_blank"
+             href="#">PG</a>
         </div>
         <pre class="selected framed result nohighlight" data-transform="updateExample"
              data-frame="Sample library frame with implicit @embed set to @once"
@@ -1443,7 +1437,8 @@
           <a class="playground"
              data-result-for="#flattened-library-objects"
              data-frame="#sample-library-frame-with-explicit-embed-set-to-never"
-             target="_blank"></a>
+             target="_blank"
+             href="#">PG</a>
         </div>
         <pre class="selected framed result nohighlight" data-transform="updateExample"
              data-frame="Sample library frame with explicit @embed set to @never"
@@ -1502,7 +1497,8 @@
           <a class="playground"
              data-result-for="#flattened-library-objects-with-double-index"
              data-frame="#sample-library-frame-with-implicit-embed-set-to-once"
-             target="_blank"></a>
+             target="_blank"
+             href="#">PG</a>
         </div>
         <pre class="selected framed result nohighlight" data-transform="updateExample"
              data-frame="Sample library frame with implicit @embed set to @once"
@@ -1557,7 +1553,8 @@
           <a class="playground"
              data-result-for="#flattened-library-objects-with-double-index"
              data-frame="#sample-library-frame-with-explicit-embed-set-to-always"
-             target="_blank"></a>
+             target="_blank"
+             href="#">PG</a>
         </div>
         <pre class="selected framed result nohighlight" data-transform="updateExample"
              data-frame="Sample library frame with explicit @embed set to @always"
@@ -1644,7 +1641,8 @@
         <a class="playground"
            data-result-for="#flattened-library-objects"
            data-frame="#sample-library-frame-with-explicit-set-to-true"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected framed result nohighlight" data-transform="updateExample"
            data-frame="Sample library frame with @explicit set to true"
@@ -1743,7 +1741,8 @@
           <a class="playground"
              data-result-for="#sample-input-for-omitDefault"
              data-frame="#sample-library-frame-without-omitDefault"
-             target="_blank"></a>
+             target="_blank"
+             href="#">PG</a>
         </div>
         <pre class="selected framed result nohighlight" data-transform="updateExample"
              data-frame="Sample parent/child relationship frame without @omitDefault"
@@ -1808,7 +1807,8 @@
           <a class="playground"
              data-result-for="#sample-input-for-omitDefault"
              data-frame="#sample-library-frame-with-omitDefault"
-             target="_blank"></a>
+             target="_blank"
+             href="#">PG</a>
         </div>
         <pre class="selected framed result nohighlight" data-transform="updateExample"
              data-frame="Sample parent/child relationship frame with @omitDefault"
@@ -1865,7 +1865,8 @@
         <a class="playground"
            data-result-for="#flattened-library-objects"
            data-frame="#sample-library-frame"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected framed result" data-transform="updateExample"
            data-options="omitGraph=false"
@@ -1947,7 +1948,8 @@
           <a class="playground"
              data-result-for="#flattened-library-objects"
              data-frame="#frame-with-requireAll"
-             target="_blank"></a>
+             target="_blank"
+             href="#">PG</a>
         </div>
         <pre class="selected framed result nohighlight" data-transform="updateExample"
              data-frame="Frame with @requireAll"
@@ -2013,7 +2015,8 @@
         <a class="playground"
            data-result-for="#flattened-library-objects"
            data-frame="#inverted-library-frame"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected framed result" data-transform="updateExample"
            data-frame="Inverted library frame"
@@ -2126,7 +2129,8 @@
         <a class="playground"
            data-result-for="#flattened-input-with-named-graphs"
            data-frame="#frame-with-named-graphs"
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="selected framed result nohighlight" data-transform="updateExample"
            data-frame="Frame with named graphs"
@@ -3160,6 +3164,12 @@ becomes a W3C Recommendation.</p>
     <li>Changed `[Exposed=(Window,Worker)]` to `[Exposed=JsonLd]`,
       which is declared as a global interface in order to expose the {{JsonLdProcessor}} interface
       for non-browser usage to address review suggestions.</li>
+  </ul>
+</section>
+<section class="appendix informative" id="changes-from-rec1">
+  <h2>Changes since Recommendation of 16 July 2020</h2>
+  <ul>
+    <li>Regenerated definition list, which does not attempt to filter out unused definitions.</li>
   </ul>
 </section>
 


### PR DESCRIPTION
* Use respec-w3c instead of respec-w3c-comman.
* Update ReSpec configuration to use group: "wg/json-ld" instead of separate wg* attributes.
* Update playground links to not be flagged by ReSpec.
* Other changes to common files.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/112.html" title="Last updated on Nov 13, 2020, 10:46 PM UTC (7be45c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/112/ddd2ad0...7be45c1.html" title="Last updated on Nov 13, 2020, 10:46 PM UTC (7be45c1)">Diff</a>