### PR TITLE
Comment out normative update

### DIFF
--- a/index.html
+++ b/index.html
@@ -2936,6 +2936,15 @@ becomes a W3C Recommendation.</p>
   <dt>Subtype name:</dt>
   <dd class="changed">ld+json</dd>
   <dt class="changed">Required parameters:</dt>
+  <!--
+    These three lines should be removed when re-published,
+    as this is a required, not optional paameter and
+    should be "#frame" not "#framed"
+  -->
+  <dd>None</dd>
+  <dt class="changed">Optional parameters:</dt>
+  <dd class="changed">
+  <!-- End deferred update -->
     <dl>
       <dt><code>profile</code></dt>
       <dd>
@@ -2945,17 +2954,22 @@ becomes a W3C Recommendation.</p>
           and without knowledge of a profiled resource can safely use the same
           representation.</p>
         <dl>
-          <dt><code>http://www.w3.org/ns/json-ld#frame</code></dt>
+          <!-- When re-publishing changed to #frame -->
+          <dt><code>http://www.w3.org/ns/json-ld#framed</code></dt>
           <dd>To request or specify a <a data-lt="frame">JSON-LD Frame document</a>.</dd>
         </dl>
-        <p>The <code>http://www.w3.org/ns/json-ld#frame</code> `profile` parameter SHOULD
+        <!-- When re-publishing changed to #frame -->
+        <p>The <code>http://www.w3.org/ns/json-ld#framed</code> `profile` parameter SHOULD
           be used when serving and requesting a
           <a data-lt="frame">JSON-LD Frame document</a>.</p>
       </dd>
     </dl>
+  <!--
+    The following lines should be added back when re-published.
   <dt class="changed">Optional parameters:</dt>
   <dd class="changed">
     None.
+  -->
   </dd>
   <dt>Encoding considerations:</dt>
   <dd>See <a data-cite="RFC8259#section-11">RFC&nbsp;8259, section 11</a>.</dd>
@@ -3132,6 +3146,7 @@ becomes a W3C Recommendation.</p>
   <h2>Changes since Recommendation of 16 July 2020</h2>
   <ul>
     <li>Regenerated definition list, which does not attempt to filter out unused definitions.</li>
+    <!-- The fllowing entry can be added back when re-publishing
     <li>Updated <a href="#iana-considerations" class="sectionRef"></a>
       to describe the `http://www.w3.org/ns/json-ld#frame`
       `profile` parameter as a required parameter,
@@ -3139,7 +3154,8 @@ becomes a W3C Recommendation.</p>
       as an optional parameter to be consistent with the textual
       description and the description of the same parameter
       in [[JSON-LD11]] <a data-cite="JSON-LD11#iana-considerations">IANA Considerations</a>.
-    This is in response to <a href="https://github.com/w3c/json-ld-framing/issues/132">Issue 132</a>.</li>
+      This is in response to <a href="https://github.com/w3c/json-ld-framing/issues/132">Issue 132</a>.</li>
+    -->
     <li>Updated
       <a href="#jsonldprocessor" class="sectionRef"></a> and
       <a href="#jsonldoptions" class="sectionRef"></a>


### PR DESCRIPTION
... introduced in #134 relating to #132.

These corrected the IANA parameter identifying a frame from "#frame" to "#framed". As the changes were normative, these should be withheld until we are ready to go through the CR process again.
