### PR TITLE
Add note on running tests that `processingMode` set to `json-ld-1.0` …

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -40,6 +40,10 @@ Implementations create their own infrastructure for running the test suite. In p
 * Some algorithms, may not preserve the order of statements listed in the input document, and provision should be taken for performing unordered array comparison, for arrays other than values of `@list`. (This may be difficult for compacted results, where array value ordering is dependent on the associated term definition).
 * Some implementations may choose an alternative Blank Node Label algorithm, the comparison between documents containing blank node labels should take this into consideration. (One way to do this may be to reduce both results and _expected_ to datsets to extract a bijective mapping of blank node labels between the two datasets as described in [RDF Dataset Isomorphism](https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism)).
 * Note that the `"@embed": "@once"` test behavior requires that the `ordered` option be set to `true` for repeatability.
+* Some tests may set the `specVersion` option to "json-ld-1.1" but have a `processingMode` of "json-ld-1.0".
+  This is set for tests which were not originally included in the JSON-LD 1.0 version of the test suite,
+  but only apply to a processor operating in json-ld-1.0 mode.
+  Passing such tests is not required to show conformance with JSON-LD 1.1.
 
 # Contributing
 


### PR DESCRIPTION
…is for tests only operating in JSON-LD 1.0 mode, and is not required to show conformance.

Fixes #110.