### PR TITLE
Fix omitgraph example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1861,7 +1861,7 @@
       or by setting the <a>omit graph flag</a> to `false`.</p>
 
     <aside class="example ds-selector-tabs"
-           title="Framed library objects with @omitGraph set to false">
+           title="Framed library objects with omitGraph set to false">
       <div class="selectors">
         <a class="playground"
            data-result-for="#flattened-library-objects"
@@ -3165,6 +3165,11 @@ becomes a W3C Recommendation.</p>
       to correct invalid WebIDL.
       Also updated internal references to use appropriate reference syntax.
       This is in response to <a href="https://github.com/w3c/json-ld-framing/issues/136">Issue 136</a>.
+    </li>
+    <li>
+      Updated label on <a href="#example-framed-library-objects-with-omitgraph-set-to-false">Example 41</a>
+      to use `omitGraph` instead of `@omitGraph`,
+      as {{JsonLdOptions/omitGraph}} is an API option, not a <a>framing keyword</a>.
     </li>
   </ul>
 </section>


### PR DESCRIPTION
Change `@omitGraph` to `omitGraph` in comment to example 41.

Fixes #116.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/139.html" title="Last updated on Oct 26, 2022, 4:49 PM UTC (b323c9f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/139/a0eb400...b323c9f.html" title="Last updated on Oct 26, 2022, 4:49 PM UTC (b323c9f)">Diff</a>