### PR TITLE
fixed frame on type `@json`

### DIFF
--- a/tests/frame/0069-frame.jsonld
+++ b/tests/frame/0069-frame.jsonld
@@ -3,8 +3,5 @@
     "ex": "http://example.org/vocab#",
     "ex:info": {"@type": "@json"}
   },
-  "http://example.org/vocab#info": {
-    "@value": {},
-    "@type": "@json"
-  }
+  "ex:info": {}
 }


### PR DESCRIPTION
Fixed the frame for the case of framing over a `@json` attribute.
The previous frame expanded incorrectly as:
```json
[
  {
    "http://example.org/vocab#info": [
      {
        "@type": "@json",
        "@value": {
          "@value": {},
          "@type": "@json"
        }
      }
    ]
  }
]
```

This frame expands instead as:
```json
[
  {
    "http://example.org/vocab#info": [
      {
        "@type": "@json",
        "@value": {}
      }
    ]
  }
]
```
which should be the expected expansion.