### PR TITLE
Clarify that lexicographical order uses code point ordering.

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -1,5 +1,5 @@
 <section><h3>Terms imported from Other Specifications</h3>
-<p>Terms imported from [[[ECMASCRIPT]]] [[ECMASCRIPT]], [[[RFC8259]]] [[RFC8259]], [[[INFRA]]] [[INFRA]], [[XPATH-FUNCTIONS]], and [[[WEBIDL]]] [[WEBIDL]]</p>
+<p>Terms imported from [[[ECMASCRIPT]]] [[ECMASCRIPT]], [[[RFC8259]]] [[RFC8259]], [[[INFRA]]] [[INFRA]], [[[XPATH-FUNCTIONS]]] [[XPATH-FUNCTIONS]], and [[[WEBIDL]]] [[WEBIDL]]</p>
 <dl class="termlist" data-sort>
   <dt><dfn data-cite="INFRA#list" class="preserve">array</dfn></dt><dd>
     In the JSON serialization,
@@ -58,7 +58,7 @@
   <dt><dfn data-cite="XPATH-FUNCTIONS#codepoint-collation" data-lt="code point order|code point ordered|unicode codepoint collation">Unicode code point order</dfn></dt>
   <dd>This refers to determining the order of two Unicode strings (`A` and `B`),
     using <a>Unicode Codepoint Collation</a>,
-    as defined in [[XPATH-FUNCTIONS]],
+    as defined in [[[XPATH-FUNCTIONS]]] [[XPATH-FUNCTIONS]],
     which defines a
     <a href="https://en.wikipedia.org/wiki/Total_order">total ordering</a>
     of <a>strings</a> comparing <a data-cite="INFRA#code-point">code points</a>.

--- a/common/terms.html
+++ b/common/terms.html
@@ -1,5 +1,5 @@
 <section><h3>Terms imported from Other Specifications</h3>
-<p>Terms imported from [[[ECMASCRIPT]]] [[ECMASCRIPT]], [[[RFC8259]]] [[RFC8259]], [[[INFRA]]] [[INFRA]], and [[[WEBIDL]]] [[WEBIDL]]</p>
+<p>Terms imported from [[[ECMASCRIPT]]] [[ECMASCRIPT]], [[[RFC8259]]] [[RFC8259]], [[[INFRA]]] [[INFRA]], [[XPATH-FUNCTIONS]], and [[[WEBIDL]]] [[WEBIDL]]</p>
 <dl class="termlist" data-sort>
   <dt><dfn data-cite="INFRA#list" class="preserve">array</dfn></dt><dd>
     In the JSON serialization,
@@ -55,6 +55,15 @@
     is a sequence of zero or more Unicode (UTF-8) characters,
     wrapped in double quotes, using backslash escapes (if necessary).
     A character is represented as a single character string.</dd>
+  <dt><dfn data-cite="XPATH-FUNCTIONS#codepoint-collation" data-lt="code point order|code point ordered|unicode codepoint collation">Unicode code point order</dfn></dt>
+  <dd>This refers to determining the order of two Unicode strings (`A` and `B`),
+    using <a>Unicode Codepoint Collation</a>,
+    as defined in [[XPATH-FUNCTIONS]],
+    which defines a
+    <a href="https://en.wikipedia.org/wiki/Total_order">total ordering</a>
+    of <a>strings</a> comparing <a data-cite="INFRA#code-point">code points</a>.
+    Note that for UTF-8 encoded strings, comparing the byte sequences gives the same result as <a>code point order</a>.
+  </dd>
 </dl>
 
 <p>Terms imported from [[[RFC3987]]] [[RFC3987]]</p>

--- a/index.html
+++ b/index.html
@@ -2301,7 +2301,7 @@
     using the <a href="#frame-matching">Frame Matching algorithm</a>
     with <var>state</var>, <var>subjects</var>, <var>frame</var>, and <var>requireAll</var>.</li>
   <li>For each <var>id</var> and associated <a>node object</a> <var>node</var>
-    from the set of matched subjects, ordered lexicographically by <var>id</var>
+    from the set of matched subjects, in <a>code point order</a> by <var>id</var>
     <span class="changed">if the optional {{JsonLdOptions/ordered}} flag is <code>true</code></span>:
     <ol>
       <li>Initialize <var>output</var> to a new <a>map</a> with <code>@id</code> and <var>id</var>.</li>
@@ -2352,7 +2352,8 @@
         <var>subjects</var>, <var>frame</var>,
         <var>output</var> as <var>parent</var>, and `@included` as <var>active property</var>.
       </li>
-      <li>For each <var>property</var> and <var>objects</var> in <var>node</var>, ordered lexicographically by <var>property</var>
+      <li>For each <var>property</var> and <var>objects</var> in <var>node</var>,
+        in <a>code point order</a> by <var>property</var>
         <span class="changed">if the optional {{JsonLdOptions/ordered}} flag is <code>true</code></span>:
         <ol>
           <li>If <var>property</var> is a <a>keyword</a>, add <var>property</var> and <var>objects</var>
@@ -3171,6 +3172,7 @@ becomes a W3C Recommendation.</p>
       to use `omitGraph` instead of `@omitGraph`,
       as {{JsonLdOptions/omitGraph}} is an API option, not a <a>framing keyword</a>.
     </li>
+    <li>Use <a>code point order</a> as a better definition for the more vague "lexicographical order".</li>
   </ul>
 </section>
 


### PR DESCRIPTION
For #141.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/pull/153.html" title="Last updated on Aug 8, 2023, 9:09 PM UTC (e53095a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-framing/153/17b2e78...e53095a.html" title="Last updated on Aug 8, 2023, 9:09 PM UTC (e53095a)">Diff</a>