### PR TITLE
Fix links to framing test suite

### DIFF
--- a/tests/frame-manifest.html
+++ b/tests/frame-manifest.html
@@ -31,7 +31,7 @@
     <p>For <strong>NegativeEvaluationTests</strong>, the result is a string associated with the expected error code.</p>
     <p>Unless <code>processingMode</code> is set explicitly in a test entry, <code>processingMode</code> is compatible with both <code>json-ld-1.0</code> and <code>json-ld-1.1</code>.</p>
     <p>Test results that include a context input presume that the context is provided locally, and not from the referenced location, thus the results will include the content of the context file, rather than a reference.</p>
-    <p>Developers are encouraged to make a local copy of the test suite (available on <a href="http://github.com/w3c/json-ld-api/tests/">GitHub</a>) and simulate the behavior of fetching test files remotely and setting HTTP headers as described in a particular test entry.</p>
+    <p>Developers are encouraged to make a local copy of the test suite (available on <a href="https://github.com/w3c/json-ld-framing/tree/main/tests">GitHub</a>) and simulate the behavior of fetching test files remotely and setting HTTP headers as described in a particular test entry.</p>
     <h2 id="json-ld-object-comparison">JSON-LD Object comparison</h2>
     <p>If algorithms are invoked with the <code>ordered</code> flag set to <code>true</code>, simple JSON Object comparison may be used, as the order of all arrays will be preserved (except for <em>fromRdf</em>, unless the input quads are also ordered). If <code>ordered</code> is <code>false</code>, then the following algorithm will ensure arrays other than values of <code>@list</code> are compared without regard to order.</p>
     <p>JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.</p>

--- a/tests/manifest.html
+++ b/tests/manifest.html
@@ -42,7 +42,7 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <p>Test results that include a context input presume that the context is provided locally, and not from the referenced location, thus the results will include the content of the context file, rather than a reference.</p>
 
-<p>Developers are encouraged to make a local copy of the test suite (available on <a href="http://github.com/w3c/json-ld-api/tests/">GitHub</a>) and simulate the behavior of fetching test files remotely and setting HTTP headers as described in a particular test entry.</p>
+<p>Developers are encouraged to make a local copy of the test suite (available on <a href="https://github.com/w3c/json-ld-framing/tree/main/tests">GitHub</a>) and simulate the behavior of fetching test files remotely and setting HTTP headers as described in a particular test entry.</p>
 
 <h2 id="json-ld-object-comparison">JSON-LD Object comparison</h2>
 

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -43,7 +43,7 @@
 
       Test results that include a context input presume that the context is provided locally, and not from the referenced location, thus the results will include the content of the context file, rather than a reference.
 
-      Developers are encouraged to make a local copy of the test suite (available on [GitHub](http://github.com/w3c/json-ld-api/tests/)) and simulate the behavior of fetching test files remotely and setting HTTP headers as described in a particular test entry.
+      Developers are encouraged to make a local copy of the test suite (available on [GitHub](https://github.com/w3c/json-ld-framing/tree/main/tests)) and simulate the behavior of fetching test files remotely and setting HTTP headers as described in a particular test entry.
 
       <h2 id="json-ld-object-comparison">JSON-LD Object comparison</h2>
 


### PR DESCRIPTION
As in the [json-ld-api repo](https://github.com/search?q=repo%3Aw3c%2Fjson-ld-api%20https%3A%2F%2Fgithub.com%2Fw3c%2Fjson-ld-api%2Ftree%2Fmain%2Ftests&type=code).